### PR TITLE
fix #24: crash on sync if cTag is missing

### DIFF
--- a/src/sync.d
+++ b/src/sync.d
@@ -180,7 +180,15 @@ final class SyncEngine
 			return;
 		}
 
-		string cTag = item["cTag"].str;
+		string cTag;
+                try {
+                        cTag = item["cTag"].str;
+                } catch (JSONException e) {
+                        // cTag is not returned if the Item is a folder
+                        // https://dev.onedrive.com/resources/item.htm
+                        cTag = "";
+                }
+
 		string mtime = item["fileSystemInfo"]["lastModifiedDateTime"].str;
 
 		string crc32;


### PR DESCRIPTION
According to https://dev.onedrive.com/resources/item.htm
cTag property is not returned if the Item is a folder.

This fixes issue #24 for me.
I am not sure if cTag should be set to an empty string or just a copy of eTag in this case.
