### PR TITLE
add a user-friendly message how to create config

### DIFF
--- a/src/config.d
+++ b/src/config.d
@@ -1,4 +1,4 @@
-import std.file, std.regex, std.stdio;
+import std.file, std.regex, std.stdio, std.array;
 
 struct Config
 {
@@ -13,7 +13,30 @@ struct Config
 				load(filename);
 			}
 		}
-		if (!found) throw new Exception("No config file found");
+		if (!found) {
+                        if (filenames && filenames[0] != "empty") { // not a unit test
+                            writeln("Configuration file is not found.");
+                            writeln();
+                            writeln("If this is the first time you run onedrive, you should create a configuration");
+                            writeln("file in ", join(filenames.reverse, " or "), ". Run:");
+                            writeln();
+                            writeln("mkdir -p ~/.config/onedrive");
+                            writeln("cat > ~/.config/onedrive/config << EOF");
+                            writeln("client_id = \"\"");
+                            writeln("client_secret = \"\"");
+                            writeln("sync_dir = \"~/OneDrive\"");
+                            writeln("skip_file = \".*|~*\"");
+                            writeln("skip_dir = \".*\"");
+                            writeln("EOF");
+                            writeln();
+                            writeln("Then edit ~/.config/onedrive/config.");
+                            writeln("To get client_id and client_secret, please register this application at");
+                            writeln("https://dev.onedrive.com/app-registration.htm");
+                            writeln("and copy both keys from App Settings.");
+                            writeln();
+                        }
+                        throw new Exception("No config file found");
+                }
 	}
 
 	string get(string key)

--- a/src/main.d
+++ b/src/main.d
@@ -3,6 +3,16 @@ import std.getopt, std.file, std.path, std.process, std.stdio;
 import config, itemdb, monitor, onedrive, sync, util;
 
 
+void createSyncDir(string syncDirFullPath) {
+    if (!exists(syncDirFullPath)) {
+        mkdirRecurse(syncDirFullPath);
+    } else if (isFile(syncDirFullPath)) {
+        writeln(syncDirFullPath, " is a file, should be a directory.");
+        throw new Exception("sync_dir is a file, should be a directory.");
+    }
+}
+
+
 void main(string[] args)
 {
 	// always print log messages
@@ -71,6 +81,7 @@ void main(string[] args)
 
 	string syncDir = expandTilde(cfg.get("sync_dir"));
 	if (verbose) writeln("All operations will be performed in: ", syncDir);
+        createSyncDir(syncDir);
 	chdir(syncDir);
 
 	if (verbose) writeln("Initializing the Synchronization Engine ...");


### PR DESCRIPTION
Two changes to improve first user experience:
- print instructions how to create config and register the app if the config is missing
- create sync_dir automatically if it doesn't exist

Currently the program just dumps a backtrace in both cases.

Backtrace on the first run of the program could be confusing to many users. Personally I ran it through strace to find out where I should put the config. While the information is already in the README, I believe that a giving more specific suggestions to the user can improve user experience.

Before this patch:

```
$ ./onedrive 
object.Exception@src/config.d(16): No config file found
----------------
??:? ref config.Config config.Config.__ctor(immutable(char)[][]...) [0x5b8666]
??:? _Dmain [0x5bd11a]
??:? _D2rt6dmain211_d_run_mainUiPPaPUAAaZiZ6runAllMFZ9__lambda1MFZv [0x5d8a42]
??:? void rt.dmain2._d_run_main(int, char**, extern (C) int function(char[][])*).tryExec(scope void delegate()) [0x5d8980]
??:? void rt.dmain2._d_run_main(int, char**, extern (C) int function(char[][])*).runAll() [0x5d89fe]
??:? void rt.dmain2._d_run_main(int, char**, extern (C) int function(char[][])*).tryExec(scope void delegate()) [0x5d8980]
??:? _d_run_main [0x5d88dd]
??:? main [0x5bf915]
??:? __libc_start_main [0x67d7dec4]
```

After this patch:

```
$ ./onedrive 
Configuration file is not found.

If this is the first time you run onedrive, you should create a configuration
file in /home/sergey/.config/onedrive/config or /usr/local/etc/onedrive.conf or /etc/onedrive.conf. Run:

mkdir -p ~/.config/onedrive
cat > ~/.config/onedrive/config << EOF
client_id = ""
client_secret = ""
sync_dir = "~/OneDrive"
skip_file = ".*|~*"
skip_dir = ".*"
EOF

Then edit ~/.config/onedrive/config.
To get client_id and client_secret, please register this application at
https://dev.onedrive.com/app-registration.htm
and copy both keys from App Settings.

object.Exception@src/config.d(38): No config file found
----------------
??:? ref config.Config config.Config.__ctor(immutable(char)[][]...) [0x5b9285]
??:? _Dmain [0x5bdd4a]
??:? _D2rt6dmain211_d_run_mainUiPPaPUAAaZiZ6runAllMFZ9__lambda1MFZv [0x5d9736]
??:? void rt.dmain2._d_run_main(int, char**, extern (C) int function(char[][])*).tryExec(scope void delegate()) [0x5d9674]
??:? void rt.dmain2._d_run_main(int, char**, extern (C) int function(char[][])*).runAll() [0x5d96f2]
??:? void rt.dmain2._d_run_main(int, char**, extern (C) int function(char[][])*).tryExec(scope void delegate()) [0x5d9674]
??:? _d_run_main [0x5d95d1]
??:? main [0x5c0545]
??:? __libc_start_main [0x3d546ec4]
```
