### PR TITLE
Fix install in case no /usr/local/* exists

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,8 +26,8 @@ clean:
 	rm -f onedrive.o onedrive
 
 install: onedrive onedrive.conf
-	install onedrive $(DESTDIR)
-	install -m 644 onedrive.conf $(CONFDIR)
+	install onedrive $(DESTDIR)/onedrive
+	install -m 644 onedrive.conf $(CONFDIR)/onedrive.conf
 	install -m 644 onedrive.service /usr/lib/systemd/user
 
 uninstall:


### PR DESCRIPTION
When installed the *onedrive.conf* file content was copied to the **file** /usr/local/etc, instead of creating the **missing** directory etc/ and then copying inside the file *onedrive.conf*.