### PR TITLE
Ignore antivirus errors when downloading files

### DIFF
--- a/src/onedrive.d
+++ b/src/onedrive.d
@@ -99,7 +99,7 @@ final class OneDriveApi
 			import std.file;
 			if (exists(saveToPath)) remove(saveToPath);
 		}
-		char[] url = itemByIdUrl ~ id ~ "/content";
+		char[] url = itemByIdUrl ~ id ~ "/content?AVOverride=1";
 		download(url, saveToPath);
 	}
 


### PR DESCRIPTION
- closes #31

See OneDrive/onedrive-api-docs#178 for some investigation of this issue.