### PR TITLE
Move MakeFile variables to more standard definitions and update service file automatically

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .*
 onedrive
 onedrive.o
+onedrive.service

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 DC = dmd
 DFLAGS = -ofonedrive -L-lcurl -L-lsqlite3 -L-ldl
-DESTDIR = /usr/local/bin
-CONFDIR = /usr/local/etc
+PREFIX = /usr/local
+SYSCONFDIR = $(PREFIX)/etc
 
 SOURCES = \
 	src/config.d \
@@ -24,11 +24,11 @@ clean:
 	rm -f onedrive.o onedrive
 
 install: onedrive onedrive.conf
-	install onedrive $(DESTDIR)/onedrive
-	install -m 644 onedrive.conf $(CONFDIR)/onedrive.conf
-	install -m 644 onedrive.service /usr/lib/systemd/user
+	install -D -m 755 onedrive $(DESTDIR)$(PREFIX)/bin/onedrive
+	install -D -m 644 onedrive.conf $(DESTDIR)$(SYSCONFDIR)/onedrive.conf
+	install -D -m 644 onedrive.service $(DESTDIR)/usr/lib/systemd/user/onedrive.service
 
 uninstall:
-	rm -f $(DESTDIR)/onedrive
-	rm -f $(CONFDIR)/onedrive.conf
-	rm -f /usr/lib/systemd/user/onedrive.service
+	rm -f $(DESTDIR)$(PREFIX)/bin/onedrive
+	rm -f $(DESTDIR)$(SYSCONFDIR)/onedrive.conf
+	rm -f $(DESTDIR)/usr/lib/systemd/user/onedrive.service

--- a/Makefile
+++ b/Makefile
@@ -14,6 +14,11 @@ SOURCES = \
 	src/upload.d \
 	src/util.d
 
+all: onedrive service
+
+service:
+	sed "s|@PREFIX@|$(PREFIX)|g" onedrive.service.in > onedrive.service
+
 onedrive: $(SOURCES)
 	$(DC) -O -release -inline -boundscheck=off $(DFLAGS) $(SOURCES)
 
@@ -21,9 +26,9 @@ debug: $(SOURCES)
 	$(DC) -unittest -debug -g -gs $(DFLAGS) $(SOURCES)
 
 clean:
-	rm -f onedrive.o onedrive
+	rm -f onedrive.o onedrive onedrive.service
 
-install: onedrive onedrive.conf
+install: onedrive onedrive.conf service
 	install -D -m 755 onedrive $(DESTDIR)$(PREFIX)/bin/onedrive
 	install -D -m 644 onedrive.conf $(DESTDIR)$(SYSCONFDIR)/onedrive.conf
 	install -D -m 644 onedrive.service $(DESTDIR)/usr/lib/systemd/user/onedrive.service

--- a/onedrive.service.in
+++ b/onedrive.service.in
@@ -3,7 +3,7 @@ Description=OneDrive Free Client
 Documentation=https://github.com/skilion/onedrive
 
 [Service]
-ExecStart=/usr/local/bin/onedrive -m
+ExecStart=@PREFIX@/bin/onedrive -m
 Restart=no
 
 [Install]

--- a/src/main.d
+++ b/src/main.d
@@ -32,8 +32,9 @@ void main(string[] args)
 
 	string configDirName = expandTilde(environment.get("XDG_CONFIG_HOME", "~/.config")) ~ "/onedrive";
 	string configFile1Path = "/etc/onedrive.conf";
-	string configFile2Path = "/usr/local/etc/onedrive.conf";
+	string configFile2Path = dirName(thisExePath()) ~ "/../etc/onedrive.conf";
 	string configFile3Path = configDirName ~ "/config";
+	string configFile4Path = dirName(thisExePath()) ~ "/onedrive.conf";
 	string refreshTokenFilePath = configDirName ~ "/refresh_token";
 	string statusTokenFilePath = configDirName ~ "/status_token";
 	string databaseFilePath = configDirName ~ "/items.db";
@@ -47,7 +48,7 @@ void main(string[] args)
 	}
 
 	if (verbose) writeln("Loading config ...");
-	auto cfg = config.Config(configFile1Path, configFile2Path, configFile3Path);
+	auto cfg = config.Config(configFile1Path, configFile2Path, configFile3Path, configFile4Path);
 
 	if (verbose) writeln("Initializing the OneDrive API ...");
 	bool online = testNetwork();


### PR DESCRIPTION
DESTDIR should be used to change the location the entire directory tree is installed, like when packaging. This uses variable names that are common with autotools and cmake.
