### PR TITLE
Avoid syncing broken symbolic link

### DIFF
--- a/src/sync.d
+++ b/src/sync.d
@@ -439,9 +439,9 @@ final class SyncEngine
 
 	private void uploadNewItems(string path)
 	{
-    if (isSymlink(path) && !exists(readLink(path))) {
-      return;
-    }
+		if (isSymlink(path) && !exists(readLink(path))) {
+			return;
+		}
 		if (isDir(path)) {
 			if (path.matchFirst(skipDir).empty) {
 				Item item;

--- a/src/sync.d
+++ b/src/sync.d
@@ -439,6 +439,9 @@ final class SyncEngine
 
 	private void uploadNewItems(string path)
 	{
+    if (isSymlink(path) && !exists(readLink(path))) {
+      return;
+    }
 		if (isDir(path)) {
 			if (path.matchFirst(skipDir).empty) {
 				Item item;


### PR DESCRIPTION
# overview
This fixes crash on sync if broken symbolic link is exist.
# problem
```
ln -s ~/notExistFile ~/OneDrive/link
./onedrive -m -v
```
and stacktrace is following
```
./link: No such file or directory                                                                                                                             [437/1781]
Applying differences ...
Uploading differences ...
32F5924C3AF68756!103 root
The directory has not changed
Uploading new items ...
sync.SyncException@src/sync.d(348): ./link: No such file or directory
----------------
src/sync.d:41 void sync.SyncEngine.scanForDifferences(immutable(char)[]) [0x5ae37a]
src/main.d:154 void main.performSync(sync.SyncEngine) [0x5a126e]
src/main.d:84 _Dmain [0x5a0e56]
??:? _D2rt6dmain211_d_run_mainUiPPaPUAAaZiZ6runAllMFZ9__lambda1MFZv [0x5b7f5e]
??:? void rt.dmain2._d_run_main(int, char**, extern (C) int function(char[][])*).tryExec(scope void delegate()) [0x5b7ea8]
??:? void rt.dmain2._d_run_main(int, char**, extern (C) int function(char[][])*).runAll() [0x5b7f1a]
??:? void rt.dmain2._d_run_main(int, char**, extern (C) int function(char[][])*).tryExec(scope void delegate()) [0x5b7ea8]
??:? _d_run_main [0x5b7e19]
??:? main [0x5a330f]
??:? __libc_start_main [0x809e8290]
std.file.FileException@/usr/include/dlang/dmd/std/file.d(1436): ./link: No such file or directory
----------------
/usr/include/dlang/dmd/std/file.d:201 @trusted bool std.file.cenforce!(bool).cenforce(bool, const(char)[], const(char)*, immutable(char)[], ulong) [0x58a3f9]
/usr/include/dlang/dmd/std/file.d:190 @safe uint std.file.getAttributes!(immutable(char)[]).getAttributes(immutable(char)[]) [0x58f2a0]
/usr/include/dlang/dmd/std/file.d:1590 @property @safe bool std.file.isDir!(immutable(char)[]).isDir(immutable(char)[]) [0x58f757]
src/sync.d:445 void sync.SyncEngine.uploadNewItems(immutable(char)[]) [0x5aeb72]
src/sync.d:453 void sync.SyncEngine.uploadNewItems(immutable(char)[]) [0x5aec78]
src/sync.d:344 void sync.SyncEngine.scanForDifferences(immutable(char)[]) [0x5ae2b5]
src/main.d:154 void main.performSync(sync.SyncEngine) [0x5a126e]
src/main.d:84 _Dmain [0x5a0e56]
??:? _D2rt6dmain211_d_run_mainUiPPaPUAAaZiZ6runAllMFZ9__lambda1MFZv [0x5b7f5e]
??:? void rt.dmain2._d_run_main(int, char**, extern (C) int function(char[][])*).tryExec(scope void delegate()) [0x5b7ea8]
??:? void rt.dmain2._d_run_main(int, char**, extern (C) int function(char[][])*).runAll() [0x5b7f1a]
??:? void rt.dmain2._d_run_main(int, char**, extern (C) int function(char[][])*).tryExec(scope void delegate()) [0x5b7ea8]
??:? _d_run_main [0x5b7e19]
??:? main [0x5a330f]
??:? __libc_start_main [0x809e8290]
[1]    14262 segmentation fault (core dumped)  ./onedrive -m -v
```

In practical case, Emacs creates broken symbolic link as lockfile [1]. 
So, it's inconvenient when we edit files in the sync directory with Emacs.

[1] https://www.gnu.org/software/emacs/manual/html_node/elisp/File-Locks.html