### PR TITLE
remote-deleted directory-tree and connection through proxy

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,10 @@
+GDCARM = yes
 DC = dmd
 DFLAGS = -ofonedrive -L-lcurl -L-lsqlite3 -L-ldl
+GDC = gdc
+GDCFLAGS = -o onedrive
+GDCLIBFLAGS = -lcurl -lsqlite3 -ldl
+
 DESTDIR = /usr/local/bin
 CONFDIR = /usr/local/etc
 
@@ -15,8 +20,22 @@ SOURCES = \
 	src/upload.d \
 	src/util.d
 
+GDCPATCHES = \
+	patch/etc_c_curl.d \
+	patch/std_net_curl.d
+
+ifeq ($(GDCARM),yes)
+	UNAME_P  = $(shell uname -p)
+else
+	UNAME_P = any
+endif
+
 onedrive: $(SOURCES)
+ifneq ($(filter arm%,$(UNAME_P)),)
+	$(GDC) -frelease -fno-bounds-check $(GDCFLAGS) $(SOURCES) $(GDCPATCHES) $(GDCLIBFLAGS)
+else
 	$(DC) -O -release -inline -boundscheck=off $(DFLAGS) $(SOURCES)
+endif
 
 debug: $(SOURCES)
 	$(DC) -debug -g -gs $(DFLAGS) $(SOURCES)

--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@ GDCPATCHES = \
 	patch/std_net_curl.d
 
 ifeq ($(GDCARM),yes)
-	UNAME_P  = $(shell uname -p)
+	UNAME_P  = $(shell uname -p -m)
 else
 	UNAME_P = any
 endif

--- a/patch/etc_c_curl.d
+++ b/patch/etc_c_curl.d
@@ -1,0 +1,2314 @@
+/**
+   This is an interface to the libcurl library.
+
+   Converted to D from curl headers by $(LINK2 http://www.digitalmars.com/d/2.0/htod.html, htod) and
+   cleaned up by Jonas Drewsen (jdrewsen)
+
+   Windows x86 note:
+   A DMD compatible libcurl static library can be downloaded from the dlang.org
+   $(LINK2 http://dlang.org/download.html, download page).
+*/
+
+/* **************************************************************************
+ *                                  _   _ ____  _
+ *  Project                     ___| | | |  _ \| |
+ *                             / __| | | | |_) | |
+ *                            | (__| |_| |  _ <| |___
+ *                             \___|\___/|_| \_\_____|
+ */
+
+/**
+ * Copyright (C) 1998 - 2010, Daniel Stenberg, &lt;daniel@haxx.se&gt;, et al.
+ *
+ * This software is licensed as described in the file COPYING, which
+ * you should have received as part of this distribution. The terms
+ * are also available at $(LINK http://curl.haxx.se/docs/copyright.html).
+ *
+ * You may opt to use, copy, modify, merge, publish, distribute and/or sell
+ * copies of the Software, and permit persons to whom the Software is
+ * furnished to do so, under the terms of the COPYING file.
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTY OF ANY
+ * KIND, either express or implied.
+ *
+ ***************************************************************************/
+
+module etc.c.curl;
+
+import core.stdc.time;
+import core.stdc.config;
+import std.socket;
+
+// linux
+import core.sys.posix.sys.socket;
+
+//
+// LICENSE FROM CURL HEADERS
+//
+
+/** This is the global package copyright */
+enum LIBCURL_COPYRIGHT = "1996 - 2010 Daniel Stenberg, <daniel@haxx.se>.";
+
+/** This is the version number of the libcurl package from which this header
+   file origins: */
+enum LIBCURL_VERSION = "7.21.4";
+
+/** The numeric version number is also available "in parts" by using these
+   constants */
+enum LIBCURL_VERSION_MAJOR = 7;
+/// ditto
+enum LIBCURL_VERSION_MINOR = 21;
+/// ditto
+enum LIBCURL_VERSION_PATCH = 4;
+
+/** This is the numeric version of the libcurl version number, meant for easier
+   parsing and comparions by programs. The LIBCURL_VERSION_NUM define will
+   always follow this syntax:
+
+         0xXXYYZZ
+
+   Where XX, YY and ZZ are the main version, release and patch numbers in
+   hexadecimal (using 8 bits each). All three numbers are always represented
+   using two digits.  1.2 would appear as "0x010200" while version 9.11.7
+   appears as "0x090b07".
+
+   This 6-digit (24 bits) hexadecimal number does not show pre-release number,
+   and it is always a greater number in a more recent release. It makes
+   comparisons with greater than and less than work.
+*/
+
+enum LIBCURL_VERSION_NUM = 0x071504;
+
+/**
+ * This is the date and time when the full source package was created. The
+ * timestamp is not stored in git, as the timestamp is properly set in the
+ * tarballs by the maketgz script.
+ *
+ * The format of the date should follow this template:
+ *
+ * "Mon Feb 12 11:35:33 UTC 2007"
+ */
+enum LIBCURL_TIMESTAMP = "Thu Feb 17 12:19:40 UTC 2011";
+
+/** Data type definition of curl_off_t. */
+/// jdrewsen - Always 64bit signed and that is what long is in D.
+/// Comment below is from curlbuild.h:
+/**
+ * NOTE 2:
+ *
+ * For any given platform/compiler curl_off_t must be typedef'ed to a
+ * 64-bit wide signed integral data type. The width of this data type
+ * must remain constant and independent of any possible large file
+ * support settings.
+ *
+ * As an exception to the above, curl_off_t shall be typedef'ed to a
+ * 32-bit wide signed integral data type if there is no 64-bit type.
+ */
+alias long curl_off_t;
+
+///
+alias void CURL;
+
+/// jdrewsen - Get socket alias from std.socket
+alias socket_t curl_socket_t;
+
+/// jdrewsen - Would like to get socket error constant from std.socket by it is private atm.
+version(Windows) {
+  private import core.sys.windows.windows, core.sys.windows.winsock2;
+  enum CURL_SOCKET_BAD = SOCKET_ERROR;
+}
+version(Posix) enum CURL_SOCKET_BAD = -1;
+
+///
+extern (C) struct curl_httppost
+{
+    curl_httppost *next;        /** next entry in the list */
+    char *name;                 /** pointer to allocated name */
+    c_long namelength;          /** length of name length */
+    char *contents;             /** pointer to allocated data contents */
+    c_long contentslength;      /** length of contents field */
+    char *buffer;               /** pointer to allocated buffer contents */
+    c_long bufferlength;        /** length of buffer field */
+    char *contenttype;          /** Content-Type */
+    curl_slist *contentheader;  /** list of extra headers for this form */
+    curl_httppost *more;        /** if one field name has more than one
+                                    file, this link should link to following
+                                    files */
+    c_long flags;               /** as defined below */
+    char *showfilename;         /** The file name to show. If not set, the
+                                    actual file name will be used (if this
+                                    is a file part) */
+    void *userp;                /** custom pointer used for
+                                    HTTPPOST_CALLBACK posts */
+}
+
+enum HTTPPOST_FILENAME    = 1;  /** specified content is a file name */
+enum HTTPPOST_READFILE    = 2;  /** specified content is a file name */
+enum HTTPPOST_PTRNAME     = 4;  /** name is only stored pointer
+                                    do not free in formfree */
+enum HTTPPOST_PTRCONTENTS = 8;  /** contents is only stored pointer
+                                    do not free in formfree */
+enum HTTPPOST_BUFFER      = 16; /** upload file from buffer */
+enum HTTPPOST_PTRBUFFER   = 32; /** upload file from pointer contents */
+enum HTTPPOST_CALLBACK    = 64; /** upload file contents by using the
+                                    regular read callback to get the data
+                                    and pass the given pointer as custom
+                                    pointer */
+
+///
+alias int function(void *clientp, double dltotal, double dlnow, double ultotal, double ulnow) curl_progress_callback;
+
+/** Tests have proven that 20K is a very bad buffer size for uploads on
+   Windows, while 16K for some odd reason performed a lot better.
+   We do the ifndef check to allow this value to easier be changed at build
+   time for those who feel adventurous. The practical minimum is about
+   400 bytes since libcurl uses a buffer of this size as a scratch area
+   (unrelated to network send operations). */
+enum CURL_MAX_WRITE_SIZE = 16384;
+
+/** The only reason to have a max limit for this is to avoid the risk of a bad
+   server feeding libcurl with a never-ending header that will cause reallocs
+   infinitely */
+enum CURL_MAX_HTTP_HEADER = (100*1024);
+
+
+/** This is a magic return code for the write callback that, when returned,
+   will signal libcurl to pause receiving on the current transfer. */
+enum CURL_WRITEFUNC_PAUSE = 0x10000001;
+
+///
+alias size_t  function(char *buffer, size_t size, size_t nitems, void *outstream)curl_write_callback;
+
+/** enumeration of file types */
+enum CurlFileType {
+    file,       ///
+    directory,  ///
+    symlink,    ///
+    device_block, ///
+    device_char, ///
+    namedpipe,  ///
+    socket,     ///
+    door,       ///
+    unknown /** is possible only on Sun Solaris now */
+}
+
+///
+alias int curlfiletype;
+
+///
+enum CurlFInfoFlagKnown {
+  filename    = 1,      ///
+  filetype    = 2,      ///
+  time        = 4,      ///
+  perm        = 8,      ///
+  uid         = 16,     ///
+  gid         = 32,     ///
+  size        = 64,     ///
+  hlinkcount  = 128     ///
+}
+
+/** Content of this structure depends on information which is known and is
+   achievable (e.g. by FTP LIST parsing). Please see the url_easy_setopt(3) man
+   page for callbacks returning this structure -- some fields are mandatory,
+   some others are optional. The FLAG field has special meaning. */
+
+
+/** If some of these fields is not NULL, it is a pointer to b_data. */
+extern (C) struct _N2
+{
+    char *time;   ///
+    char *perm;   ///
+    char *user;   ///
+    char *group;  ///
+    char *target; /** pointer to the target filename of a symlink */
+}
+
+/** Content of this structure depends on information which is known and is
+   achievable (e.g. by FTP LIST parsing). Please see the url_easy_setopt(3) man
+   page for callbacks returning this structure -- some fields are mandatory,
+   some others are optional. The FLAG field has special meaning. */
+extern (C) struct curl_fileinfo
+{
+    char *filename;             ///
+    curlfiletype filetype;      ///
+    time_t time;                ///
+    uint perm;                  ///
+    int uid;                    ///
+    int gid;                    ///
+    curl_off_t size;            ///
+    c_long hardlinks;           ///
+    _N2 strings;                ///
+    uint flags;                 ///
+    char *b_data;               ///
+    size_t b_size;              ///
+    size_t b_used;              ///
+}
+
+/** return codes for CURLOPT_CHUNK_BGN_FUNCTION */
+enum CurlChunkBgnFunc {
+  ok = 0,   ///
+  fail = 1, /** tell the lib to end the task */
+  skip = 2 /** skip this chunk over */
+}
+
+/** if splitting of data transfer is enabled, this callback is called before
+   download of an individual chunk started. Note that parameter "remains" works
+   only for FTP wildcard downloading (for now), otherwise is not used */
+alias c_long function(void *transfer_info, void *ptr, int remains)curl_chunk_bgn_callback;
+
+/** return codes for CURLOPT_CHUNK_END_FUNCTION */
+enum CurlChunkEndFunc {
+  ok = 0,       ///
+  fail = 1,     ///
+}
+/** If splitting of data transfer is enabled this callback is called after
+   download of an individual chunk finished.
+   Note! After this callback was set then it have to be called FOR ALL chunks.
+   Even if downloading of this chunk was skipped in CHUNK_BGN_FUNC.
+   This is the reason why we don't need "transfer_info" parameter in this
+   callback and we are not interested in "remains" parameter too. */
+alias c_long function(void *ptr)curl_chunk_end_callback;
+
+/** return codes for FNMATCHFUNCTION */
+enum CurlFnMAtchFunc {
+  match = 0,    ///
+  nomatch = 1,  ///
+  fail = 2      ///
+}
+
+/** callback type for wildcard downloading pattern matching. If the
+   string matches the pattern, return CURL_FNMATCHFUNC_MATCH value, etc. */
+alias int  function(void *ptr, in char *pattern, in char *string)curl_fnmatch_callback;
+
+/// seek whence...
+enum CurlSeekPos {
+  set,          ///
+  current,      ///
+  end           ///
+}
+
+/** These are the return codes for the seek callbacks */
+enum CurlSeek {
+  ok,       ///
+  fail,     /** fail the entire transfer */
+  cantseek  /** tell libcurl seeking can't be done, so
+               libcurl might try other means instead */
+}
+
+///
+alias int  function(void *instream, curl_off_t offset, int origin)curl_seek_callback;
+
+///
+enum CurlReadFunc {
+  /** This is a return code for the read callback that, when returned, will
+     signal libcurl to immediately abort the current transfer. */
+  abort = 0x10000000,
+
+  /** This is a return code for the read callback that, when returned,
+     will const signal libcurl to pause sending data on the current
+     transfer. */
+  pause = 0x10000001
+}
+
+///
+alias size_t  function(char *buffer, size_t size, size_t nitems, void *instream)curl_read_callback;
+
+///
+enum CurlSockType {
+    ipcxn, /** socket created for a specific IP connection */
+    last   /** never use */
+}
+///
+alias int curlsocktype;
+
+///
+alias int  function(void *clientp, curl_socket_t curlfd, curlsocktype purpose)curl_sockopt_callback;
+
+/** addrlen was a socklen_t type before 7.18.0 but it turned really
+   ugly and painful on the systems that lack this type */
+extern (C) struct curl_sockaddr
+{
+    int family;   ///
+    int socktype; ///
+    int protocol; ///
+    uint addrlen; /** addrlen was a socklen_t type before 7.18.0 but it
+                     turned really ugly and painful on the systems that
+                     lack this type */
+    sockaddr addr; ///
+}
+
+///
+alias curl_socket_t  function(void *clientp, curlsocktype purpose, curl_sockaddr *address)curl_opensocket_callback;
+
+///
+enum CurlIoError
+{
+    ok,            /** I/O operation successful */
+    unknowncmd,    /** command was unknown to callback */
+    failrestart,   /** failed to restart the read */
+    last           /** never use */
+}
+///
+alias int curlioerr;
+
+///
+enum CurlIoCmd {
+    nop,         /** command was unknown to callback */
+    restartread, /** failed to restart the read */
+    last,        /** never use */
+}
+///
+alias int curliocmd;
+
+///
+alias curlioerr  function(CURL *handle, int cmd, void *clientp)curl_ioctl_callback;
+
+/**
+ * The following typedef's are signatures of malloc, free, realloc, strdup and
+ * calloc respectively.  Function pointers of these types can be passed to the
+ * curl_global_init_mem() function to set user defined memory management
+ * callback routines.
+ */
+alias void * function(size_t size)curl_malloc_callback;
+/// ditto
+alias void  function(void *ptr)curl_free_callback;
+/// ditto
+alias void * function(void *ptr, size_t size)curl_realloc_callback;
+/// ditto
+alias char * function(in char *str)curl_strdup_callback;
+/// ditto
+alias void * function(size_t nmemb, size_t size)curl_calloc_callback;
+
+/** the kind of data that is passed to information_callback*/
+enum CurlCallbackInfo {
+    text,       ///
+    header_in,  ///
+    header_out, ///
+    data_in,    ///
+    data_out,   ///
+    ssl_data_in, ///
+    ssl_data_out, ///
+    end         ///
+}
+///
+alias int curl_infotype;
+
+///
+alias int  function(CURL *handle,        /** the handle/transfer this concerns */
+                    curl_infotype type,  /** what kind of data */
+                    char *data,          /** points to the data */
+                    size_t size,         /** size of the data pointed to */
+                    void *userptr        /** whatever the user please */
+                    )curl_debug_callback;
+
+/** All possible error codes from all sorts of curl functions. Future versions
+   may return other values, stay prepared.
+
+   Always add new return codes last. Never *EVER* remove any. The return
+   codes must remain the same!
+ */
+enum CurlError
+{
+    ok,                          ///
+    unsupported_protocol,        /** 1 */
+    failed_init,                 /** 2 */
+    url_malformat,               /** 3 */
+    not_built_in,                /** 4 - [was obsoleted in August 2007 for
+                                    7.17.0, reused in April 2011 for 7.21.5] */
+    couldnt_resolve_proxy,       /** 5 */
+    couldnt_resolve_host,        /** 6 */
+    couldnt_connect,             /** 7 */
+    ftp_weird_server_reply,      /** 8 */
+    remote_access_denied,        /** 9 a service was denied by the server
+                                    due to lack of access - when login fails
+                                    this is not returned. */
+    obsolete10,                  /** 10 - NOT USED */
+    ftp_weird_pass_reply,        /** 11 */
+    obsolete12,                  /** 12 - NOT USED */
+    ftp_weird_pasv_reply,        /** 13 */
+    ftp_weird_227_format,        /** 14 */
+    ftp_cant_get_host,           /** 15 */
+    obsolete16,                  /** 16 - NOT USED */
+    ftp_couldnt_set_type,        /** 17 */
+    partial_file,                /** 18 */
+    ftp_couldnt_retr_file,       /** 19 */
+    obsolete20,                  /** 20 - NOT USED */
+    quote_error,                 /** 21 - quote command failure */
+    http_returned_error,         /** 22 */
+    write_error,                 /** 23 */
+    obsolete24,                  /** 24 - NOT USED */
+    upload_failed,               /** 25 - failed upload "command" */
+    read_error,                  /** 26 - couldn't open/read from file */
+    out_of_memory,               /** 27 */
+    /** Note: CURLE_OUT_OF_MEMORY may sometimes indicate a conversion error
+             instead of a memory allocation error if CURL_DOES_CONVERSIONS
+             is defined
+    */
+    operation_timedout,          /** 28 - the timeout time was reached */
+    obsolete29,                  /** 29 - NOT USED */
+    ftp_port_failed,             /** 30 - FTP PORT operation failed */
+    ftp_couldnt_use_rest,        /** 31 - the REST command failed */
+    obsolete32,                  /** 32 - NOT USED */
+    range_error,                 /** 33 - RANGE "command" didn't work */
+    http_post_error,             /** 34 */
+    ssl_connect_error,           /** 35 - wrong when connecting with SSL */
+    bad_download_resume,         /** 36 - couldn't resume download */
+    file_couldnt_read_file,      /** 37 */
+    ldap_cannot_bind,            /** 38 */
+    ldap_search_failed,          /** 39 */
+    obsolete40,                  /** 40 - NOT USED */
+    function_not_found,          /** 41 */
+    aborted_by_callback,         /** 42 */
+    bad_function_argument,       /** 43 */
+    obsolete44,                  /** 44 - NOT USED */
+    interface_failed,            /** 45 - CURLOPT_INTERFACE failed */
+    obsolete46,                  /** 46 - NOT USED */
+    too_many_redirects,          /** 47 - catch endless re-direct loops */
+    unknown_option,              /** 48 - User specified an unknown option */
+    telnet_option_syntax,        /** 49 - Malformed telnet option */
+    obsolete50,                  /** 50 - NOT USED */
+    peer_failed_verification,    /** 51 - peer's certificate or fingerprint
+                                         wasn't verified fine */
+    got_nothing,                 /** 52 - when this is a specific error */
+    ssl_engine_notfound,         /** 53 - SSL crypto engine not found */
+    ssl_engine_setfailed,        /** 54 - can not set SSL crypto engine as default */
+    send_error,                  /** 55 - failed sending network data */
+    recv_error,                  /** 56 - failure in receiving network data */
+    obsolete57,                  /** 57 - NOT IN USE */
+    ssl_certproblem,             /** 58 - problem with the local certificate */
+    ssl_cipher,                  /** 59 - couldn't use specified cipher */
+    ssl_cacert,                  /** 60 - problem with the CA cert (path?) */
+    bad_content_encoding,        /** 61 - Unrecognized transfer encoding */
+    ldap_invalid_url,            /** 62 - Invalid LDAP URL */
+    filesize_exceeded,           /** 63 - Maximum file size exceeded */
+    use_ssl_failed,              /** 64 - Requested FTP SSL level failed */
+    send_fail_rewind,            /** 65 - Sending the data requires a rewind that failed */
+    ssl_engine_initfailed,       /** 66 - failed to initialise ENGINE */
+    login_denied,                /** 67 - user, password or similar was not accepted and we failed to login */
+    tftp_notfound,               /** 68 - file not found on server */
+    tftp_perm,                   /** 69 - permission problem on server */
+    remote_disk_full,            /** 70 - out of disk space on server */
+    tftp_illegal,                /** 71 - Illegal TFTP operation */
+    tftp_unknownid,              /** 72 - Unknown transfer ID */
+    remote_file_exists,          /** 73 - File already exists */
+    tftp_nosuchuser,             /** 74 - No such user */
+    conv_failed,                 /** 75 - conversion failed */
+    conv_reqd,                   /** 76 - caller must register conversion
+                                    callbacks using curl_easy_setopt options
+                                    CURLOPT_CONV_FROM_NETWORK_FUNCTION,
+                                    CURLOPT_CONV_TO_NETWORK_FUNCTION, and
+                                    CURLOPT_CONV_FROM_UTF8_FUNCTION */
+    ssl_cacert_badfile,          /** 77 - could not load CACERT file, missing  or wrong format */
+    remote_file_not_found,       /** 78 - remote file not found */
+    ssh,                         /** 79 - error from the SSH layer, somewhat
+                                    generic so the error message will be of
+                                    interest when this has happened */
+    ssl_shutdown_failed,         /** 80 - Failed to shut down the SSL connection */
+    again,                       /** 81 - socket is not ready for send/recv,
+                                    wait till it's ready and try again (Added
+                                    in 7.18.2) */
+    ssl_crl_badfile,             /** 82 - could not load CRL file, missing or wrong format (Added in 7.19.0) */
+    ssl_issuer_error,            /** 83 - Issuer check failed.  (Added in 7.19.0) */
+    ftp_pret_failed,             /** 84 - a PRET command failed */
+    rtsp_cseq_error,             /** 85 - mismatch of RTSP CSeq numbers */
+    rtsp_session_error,          /** 86 - mismatch of RTSP Session Identifiers */
+    ftp_bad_file_list,           /** 87 - unable to parse FTP file list */
+    chunk_failed,                /** 88 - chunk callback reported error */
+    curl_last                    /** never use! */
+}
+///
+alias int CURLcode;
+
+/** This prototype applies to all conversion callbacks */
+alias CURLcode  function(char *buffer, size_t length)curl_conv_callback;
+
+/** actually an OpenSSL SSL_CTX */
+alias CURLcode  function(CURL *curl,    /** easy handle */
+                         void *ssl_ctx, /** actually an
+                                           OpenSSL SSL_CTX */
+                         void *userptr
+                         )curl_ssl_ctx_callback;
+
+///
+enum CurlProxy {
+    http,         /** added in 7.10, new in 7.19.4 default is to use CONNECT HTTP/1.1 */
+    http_1_0,     /** added in 7.19.4, force to use CONNECT HTTP/1.0  */
+    socks4 = 4,   /** support added in 7.15.2, enum existed already in 7.10 */
+    socks5 = 5,   /** added in 7.10 */
+    socks4a = 6,  /** added in 7.18.0 */
+    socks5_hostname =7   /** Use the SOCKS5 protocol but pass along the
+                         host name rather than the IP address. added
+                         in 7.18.0 */
+}
+///
+alias int curl_proxytype;
+
+///
+enum CurlAuth : long {
+  none =         0,
+  basic =        1,  /** Basic (default) */
+  digest =       2,  /** Digest */
+  gssnegotiate = 4,  /** GSS-Negotiate */
+  ntlm =         8,  /** NTLM */
+  digest_ie =    16, /** Digest with IE flavour */
+  only =         2147483648, /** used together with a single other
+                                type to force no auth or just that
+                                single type */
+  any = -17,     /* (~CURLAUTH_DIGEST_IE) */  /** all fine types set */
+  anysafe = -18  /* (~(CURLAUTH_BASIC|CURLAUTH_DIGEST_IE)) */ ///
+}
+
+///
+enum CurlSshAuth {
+  any       = -1,     /** all types supported by the server */
+  none      = 0,      /** none allowed, silly but complete */
+  publickey = 1, /** public/private key files */
+  password  = 2, /** password */
+  host      = 4, /** host key files */
+  keyboard  = 8, /** keyboard interactive */
+  default_  = -1 // CURLSSH_AUTH_ANY;
+}
+///
+enum CURL_ERROR_SIZE = 256;
+/** points to a zero-terminated string encoded with base64
+   if len is zero, otherwise to the "raw" data */
+enum CurlKHType
+{
+    unknown,    ///
+    rsa1,       ///
+    rsa,        ///
+    dss         ///
+}
+///
+extern (C) struct curl_khkey
+{
+    const(char) *key; /** points to a zero-terminated string encoded with base64
+                         if len is zero, otherwise to the "raw" data */
+    size_t len; ///
+    CurlKHType keytype; ///
+}
+
+/** this is the set of return values expected from the curl_sshkeycallback
+   callback */
+enum CurlKHStat {
+    fine_add_to_file, ///
+    fine,       ///
+    reject,  /** reject the connection, return an error */
+    defer,   /** do not accept it, but we can't answer right now so
+                this causes a CURLE_DEFER error but otherwise the
+                connection will be left intact etc */
+    last     /** not for use, only a marker for last-in-list */
+}
+
+/** this is the set of status codes pass in to the callback */
+enum CurlKHMatch {
+    ok,       /** match */
+    mismatch, /** host found, key mismatch! */
+    missing,  /** no matching host/key found */
+    last      /** not for use, only a marker for last-in-list */
+}
+
+///
+alias int  function(CURL *easy,            /** easy handle */
+                    curl_khkey *knownkey,  /** known */
+                    curl_khkey *foundkey,  /** found */
+                    CurlKHMatch m,         /** libcurl's view on the keys */
+                    void *clientp          /** custom pointer passed from app */
+                    )curl_sshkeycallback;
+
+/** parameter for the CURLOPT_USE_SSL option */
+enum CurlUseSSL {
+    none,     /** do not attempt to use SSL */
+    tryssl,   /** try using SSL, proceed anyway otherwise */
+    control,  /** SSL for the control connection or fail */
+    all,      /** SSL for all communication or fail */
+    last      /** not an option, never use */
+}
+///
+alias int curl_usessl;
+
+/** parameter for the CURLOPT_FTP_SSL_CCC option */
+enum CurlFtpSSL {
+    ccc_none,     /** do not send CCC */
+    ccc_passive,  /** Let the server initiate the shutdown */
+    ccc_active,   /** Initiate the shutdown */
+    ccc_last      /** not an option, never use */
+}
+///
+alias int curl_ftpccc;
+
+/** parameter for the CURLOPT_FTPSSLAUTH option */
+enum CurlFtpAuth {
+    defaultauth, /** let libcurl decide */
+    ssl,         /** use "AUTH SSL" */
+    tls,         /** use "AUTH TLS" */
+    last         /** not an option, never use */
+}
+///
+alias int curl_ftpauth;
+
+/** parameter for the CURLOPT_FTP_CREATE_MISSING_DIRS option */
+enum CurlFtp {
+    create_dir_none,   /** do NOT create missing dirs! */
+    create_dir,        /** (FTP/SFTP) if CWD fails, try MKD and then CWD again if MKD
+                          succeeded, for SFTP this does similar magic */
+    create_dir_retry,  /** (FTP only) if CWD fails, try MKD and then CWD again even if MKD
+                          failed! */
+    create_dir_last    /** not an option, never use */
+}
+///
+alias int curl_ftpcreatedir;
+
+/** parameter for the CURLOPT_FTP_FILEMETHOD option */
+enum CurlFtpMethod {
+    defaultmethod,    /** let libcurl pick */
+    multicwd,         /** single CWD operation for each path part */
+    nocwd,            /** no CWD at all */
+    singlecwd,        /** one CWD to full dir, then work on file */
+    last              /** not an option, never use */
+}
+///
+alias int curl_ftpmethod;
+
+/** CURLPROTO_ defines are for the CURLOPT_*PROTOCOLS options */
+enum CurlProto {
+  http   = 1,   ///
+  https  = 2,   ///
+  ftp    = 4,   ///
+  ftps   = 8,   ///
+  scp    = 16,  ///
+  sftp   = 32,  ///
+  telnet = 64,  ///
+  ldap   = 128, ///
+  ldaps  = 256, ///
+  dict   = 512, ///
+  file   = 1024,        ///
+  tftp   = 2048,        ///
+  imap   = 4096,        ///
+  imaps  = 8192,        ///
+  pop3   = 16384,       ///
+  pop3s  = 32768,       ///
+  smtp   = 65536,       ///
+  smtps  = 131072,      ///
+  rtsp   = 262144,      ///
+  rtmp   = 524288,      ///
+  rtmpt  = 1048576,     ///
+  rtmpe  = 2097152,     ///
+  rtmpte = 4194304,     ///
+  rtmps  = 8388608,     ///
+  rtmpts = 16777216,    ///
+  gopher = 33554432,    ///
+  all    = -1 /** enable everything */
+}
+
+/** long may be 32 or 64 bits, but we should never depend on anything else
+   but 32 */
+enum CURLOPTTYPE_LONG = 0;
+/// ditto
+enum CURLOPTTYPE_OBJECTPOINT = 10000;
+/// ditto
+enum CURLOPTTYPE_FUNCTIONPOINT = 20000;
+
+/// ditto
+enum CURLOPTTYPE_OFF_T = 30000;
+/** name is uppercase CURLOPT_<name>,
+   type is one of the defined CURLOPTTYPE_<type>
+   number is unique identifier */
+
+/** The macro "##" is ISO C, we assume pre-ISO C doesn't support it. */
+alias CURLOPTTYPE_LONG LONG;
+/// ditto
+alias CURLOPTTYPE_OBJECTPOINT OBJECTPOINT;
+/// ditto
+alias CURLOPTTYPE_FUNCTIONPOINT FUNCTIONPOINT;
+
+/// ditto
+alias CURLOPTTYPE_OFF_T OFF_T;
+
+///
+enum CurlOption {
+  /** This is the FILE * or void * the regular output should be written to. */
+  file = 10001,
+  /** The full URL to get/put */
+  url,
+  /** Port number to connect to, if other than default. */
+  port = 3,
+  /** Name of proxy to use. */
+  proxy = 10004,
+  /** "name:password" to use when fetching. */
+  userpwd,
+  /** "name:password" to use with proxy. */
+  proxyuserpwd,
+  /** Range to get, specified as an ASCII string. */
+  range,
+  /** not used */
+
+  /** Specified file stream to upload from (use as input): */
+  infile = 10009,
+  /** Buffer to receive error messages in, must be at least CURL_ERROR_SIZE
+   * bytes big. If this is not used, error messages go to stderr instead: */
+  errorbuffer,
+  /** Function that will be called to store the output (instead of fwrite). The
+   * parameters will use fwrite() syntax, make sure to follow them. */
+  writefunction = 20011,
+  /** Function that will be called to read the input (instead of fread). The
+   * parameters will use fread() syntax, make sure to follow them. */
+  readfunction,
+  /** Time-out the read operation after this amount of seconds */
+  timeout = 13,
+  /** If the CURLOPT_INFILE is used, this can be used to inform libcurl about
+   * how large the file being sent really is. That allows better error
+   * checking and better verifies that the upload was successful. -1 means
+   * unknown size.
+   *
+   * For large file support, there is also a _LARGE version of the key
+   * which takes an off_t type, allowing platforms with larger off_t
+   * sizes to handle larger files.  See below for INFILESIZE_LARGE.
+   */
+  infilesize,
+  /** POST static input fields. */
+  postfields = 10015,
+  /** Set the referrer page (needed by some CGIs) */
+  referer,
+  /** Set the FTP PORT string (interface name, named or numerical IP address)
+     Use i.e '-' to use default address. */
+  ftpport,
+  /** Set the User-Agent string (examined by some CGIs) */
+  useragent,
+  /** If the download receives less than "low speed limit" bytes/second
+   * during "low speed time" seconds, the operations is aborted.
+   * You could i.e if you have a pretty high speed connection, abort if
+   * it is less than 2000 bytes/sec during 20 seconds.
+   */
+
+  /** Set the "low speed limit" */
+  low_speed_limit = 19,
+  /** Set the "low speed time" */
+  low_speed_time,
+  /** Set the continuation offset.
+   *
+   * Note there is also a _LARGE version of this key which uses
+   * off_t types, allowing for large file offsets on platforms which
+   * use larger-than-32-bit off_t's.  Look below for RESUME_FROM_LARGE.
+   */
+  resume_from,
+  /** Set cookie in request: */
+  cookie = 10022,
+  /** This points to a linked list of headers, struct curl_slist kind */
+  httpheader,
+  /** This points to a linked list of post entries, struct curl_httppost */
+  httppost,
+  /** name of the file keeping your private SSL-certificate */
+  sslcert,
+  /** password for the SSL or SSH private key */
+  keypasswd,
+  /** send TYPE parameter? */
+  crlf = 27,
+  /** send linked-list of QUOTE commands */
+  quote = 10028,
+  /** send FILE * or void * to store headers to, if you use a callback it
+     is simply passed to the callback unmodified */
+  writeheader,
+  /** point to a file to read the initial cookies from, also enables
+     "cookie awareness" */
+  cookiefile = 10031,
+  /** What version to specifically try to use.
+     See CURL_SSLVERSION defines below. */
+  sslversion = 32,
+  /** What kind of HTTP time condition to use, see defines */
+  timecondition,
+  /** Time to use with the above condition. Specified in number of seconds
+     since 1 Jan 1970 */
+  timevalue,
+  /** 35 = OBSOLETE */
+
+  /** Custom request, for customizing the get command like
+     HTTP: DELETE, TRACE and others
+     FTP: to use a different list command
+     */
+  customrequest = 10036,
+  /** HTTP request, for odd commands like DELETE, TRACE and others */
+  stderr,
+  /** 38 is not used */
+
+  /** send linked-list of post-transfer QUOTE commands */
+  postquote = 10039,
+  /** Pass a pointer to string of the output using full variable-replacement
+     as described elsewhere. */
+  writeinfo,
+  verbose = 41,       /** talk a lot */
+  header,             /** throw the header out too */
+  noprogress,         /** shut off the progress meter */
+  nobody,             /** use HEAD to get http document */
+  failonerror,        /** no output on http error codes >= 300 */
+  upload,             /** this is an upload */
+  post,               /** HTTP POST method */
+  dirlistonly,        /** return bare names when listing directories */
+  append = 50,        /** Append instead of overwrite on upload! */
+  /** Specify whether to read the user+password from the .netrc or the URL.
+   * This must be one of the CURL_NETRC_* enums below. */
+  netrc,
+  followlocation, /** use Location: Luke! */
+  transfertext,  /** transfer data in text/ASCII format */
+  put,           /** HTTP PUT */
+  /** 55 = OBSOLETE */
+
+  /** Function that will be called instead of the internal progress display
+   * function. This function should be defined as the curl_progress_callback
+   * prototype defines. */
+  progressfunction = 20056,
+  /** Data passed to the progress callback */
+  progressdata = 10057,
+  /** We want the referrer field set automatically when following locations */
+  autoreferer = 58,
+  /** Port of the proxy, can be set in the proxy string as well with:
+     "[host]:[port]" */
+  proxyport,
+  /** size of the POST input data, if strlen() is not good to use */
+  postfieldsize,
+  /** tunnel non-http operations through a HTTP proxy */
+  httpproxytunnel,
+  /** Set the interface string to use as outgoing network interface */
+  intrface = 10062,
+  /** Set the krb4/5 security level, this also enables krb4/5 awareness.  This
+   * is a string, 'clear', 'safe', 'confidential' or 'private'.  If the string
+   * is set but doesn't match one of these, 'private' will be used.  */
+  krblevel,
+  /** Set if we should verify the peer in ssl handshake, set 1 to verify. */
+  ssl_verifypeer = 64,
+  /** The CApath or CAfile used to validate the peer certificate
+     this option is used only if SSL_VERIFYPEER is true */
+  cainfo = 10065,
+  /** 66 = OBSOLETE */
+  /** 67 = OBSOLETE */
+
+  /** Maximum number of http redirects to follow */
+  maxredirs = 68,
+  /** Pass a long set to 1 to get the date of the requested document (if
+     possible)! Pass a zero to shut it off. */
+  filetime,
+  /** This points to a linked list of telnet options */
+  telnetoptions = 10070,
+  /** Max amount of cached alive connections */
+  maxconnects = 71,
+  /** What policy to use when closing connections when the cache is filled
+     up */
+  closepolicy,
+  /** 73 = OBSOLETE */
+
+  /** Set to explicitly use a new connection for the upcoming transfer.
+     Do not use this unless you're absolutely sure of this, as it makes the
+     operation slower and is less friendly for the network. */
+  fresh_connect = 74,
+  /** Set to explicitly forbid the upcoming transfer's connection to be re-used
+     when done. Do not use this unless you're absolutely sure of this, as it
+     makes the operation slower and is less friendly for the network. */
+  forbid_reuse,
+  /** Set to a file name that contains random data for libcurl to use to
+     seed the random engine when doing SSL connects. */
+  random_file = 10076,
+  /** Set to the Entropy Gathering Daemon socket pathname */
+  egdsocket,
+  /** Time-out connect operations after this amount of seconds, if connects
+     are OK within this time, then fine... This only aborts the connect
+     phase. [Only works on unix-style/SIGALRM operating systems] */
+  connecttimeout = 78,
+  /** Function that will be called to store headers (instead of fwrite). The
+   * parameters will use fwrite() syntax, make sure to follow them. */
+  headerfunction = 20079,
+  /** Set this to force the HTTP request to get back to GET. Only really usable
+     if POST, PUT or a custom request have been used first.
+   */
+  httpget = 80,
+  /** Set if we should verify the Common name from the peer certificate in ssl
+   * handshake, set 1 to check existence, 2 to ensure that it matches the
+   * provided hostname. */
+  ssl_verifyhost,
+  /** Specify which file name to write all known cookies in after completed
+     operation. Set file name to "-" (dash) to make it go to stdout. */
+  cookiejar = 10082,
+  /** Specify which SSL ciphers to use */
+  ssl_cipher_list,
+  /** Specify which HTTP version to use! This must be set to one of the
+     CURL_HTTP_VERSION* enums set below. */
+  http_version = 84,
+  /** Specifically switch on or off the FTP engine's use of the EPSV command. By
+     default, that one will always be attempted before the more traditional
+     PASV command. */
+  ftp_use_epsv,
+  /** type of the file keeping your SSL-certificate ("DER", "PEM", "ENG") */
+  sslcerttype = 10086,
+  /** name of the file keeping your private SSL-key */
+  sslkey,
+  /** type of the file keeping your private SSL-key ("DER", "PEM", "ENG") */
+  sslkeytype,
+  /** crypto engine for the SSL-sub system */
+  sslengine,
+  /** set the crypto engine for the SSL-sub system as default
+     the param has no meaning...
+   */
+  sslengine_default = 90,
+  /** Non-zero value means to use the global dns cache */
+  dns_use_global_cache,
+  /** DNS cache timeout */
+  dns_cache_timeout,
+  /** send linked-list of pre-transfer QUOTE commands */
+  prequote = 10093,
+  /** set the debug function */
+  debugfunction = 20094,
+  /** set the data for the debug function */
+  debugdata = 10095,
+  /** mark this as start of a cookie session */
+  cookiesession = 96,
+  /** The CApath directory used to validate the peer certificate
+     this option is used only if SSL_VERIFYPEER is true */
+  capath = 10097,
+  /** Instruct libcurl to use a smaller receive buffer */
+  buffersize = 98,
+  /** Instruct libcurl to not use any signal/alarm handlers, even when using
+     timeouts. This option is useful for multi-threaded applications.
+     See libcurl-the-guide for more background information. */
+  nosignal,
+  /** Provide a CURLShare for mutexing non-ts data */
+  share = 10100,
+  /** indicates type of proxy. accepted values are CURLPROXY_HTTP (default),
+     CURLPROXY_SOCKS4, CURLPROXY_SOCKS4A and CURLPROXY_SOCKS5. */
+  proxytype = 101,
+  /** Set the Accept-Encoding string. Use this to tell a server you would like
+     the response to be compressed. */
+  encoding = 10102,
+  /** Set pointer to private data */
+  private_opt,
+  /** Set aliases for HTTP 200 in the HTTP Response header */
+  http200aliases,
+  /** Continue to send authentication (user+password) when following locations,
+     even when hostname changed. This can potentially send off the name
+     and password to whatever host the server decides. */
+  unrestricted_auth = 105,
+  /** Specifically switch on or off the FTP engine's use of the EPRT command ( it
+     also disables the LPRT attempt). By default, those ones will always be
+     attempted before the good old traditional PORT command. */
+  ftp_use_eprt,
+  /** Set this to a bitmask value to enable the particular authentications
+     methods you like. Use this in combination with CURLOPT_USERPWD.
+     Note that setting multiple bits may cause extra network round-trips. */
+  httpauth,
+  /** Set the ssl context callback function, currently only for OpenSSL ssl_ctx
+     in second argument. The function must be matching the
+     curl_ssl_ctx_callback proto. */
+  ssl_ctx_function = 20108,
+  /** Set the userdata for the ssl context callback function's third
+     argument */
+  ssl_ctx_data = 10109,
+  /** FTP Option that causes missing dirs to be created on the remote server.
+     In 7.19.4 we introduced the convenience enums for this option using the
+     CURLFTP_CREATE_DIR prefix.
+  */
+  ftp_create_missing_dirs = 110,
+  /** Set this to a bitmask value to enable the particular authentications
+     methods you like. Use this in combination with CURLOPT_PROXYUSERPWD.
+     Note that setting multiple bits may cause extra network round-trips. */
+  proxyauth,
+  /** FTP option that changes the timeout, in seconds, associated with
+     getting a response.  This is different from transfer timeout time and
+     essentially places a demand on the FTP server to acknowledge commands
+     in a timely manner. */
+  ftp_response_timeout,
+  /** Set this option to one of the CURL_IPRESOLVE_* defines (see below) to
+     tell libcurl to resolve names to those IP versions only. This only has
+     affect on systems with support for more than one, i.e IPv4 _and_ IPv6. */
+  ipresolve,
+  /** Set this option to limit the size of a file that will be downloaded from
+     an HTTP or FTP server.
+
+     Note there is also _LARGE version which adds large file support for
+     platforms which have larger off_t sizes.  See MAXFILESIZE_LARGE below. */
+  maxfilesize,
+  /** See the comment for INFILESIZE above, but in short, specifies
+   * the size of the file being uploaded.  -1 means unknown.
+   */
+  infilesize_large = 30115,
+  /** Sets the continuation offset.  There is also a LONG version of this;
+   * look above for RESUME_FROM.
+   */
+  resume_from_large,
+  /** Sets the maximum size of data that will be downloaded from
+   * an HTTP or FTP server.  See MAXFILESIZE above for the LONG version.
+   */
+  maxfilesize_large,
+  /** Set this option to the file name of your .netrc file you want libcurl
+     to parse (using the CURLOPT_NETRC option). If not set, libcurl will do
+     a poor attempt to find the user's home directory and check for a .netrc
+     file in there. */
+  netrc_file = 10118,
+  /** Enable SSL/TLS for FTP, pick one of:
+     CURLFTPSSL_TRY     - try using SSL, proceed anyway otherwise
+     CURLFTPSSL_CONTROL - SSL for the control connection or fail
+     CURLFTPSSL_ALL     - SSL for all communication or fail
+  */
+  use_ssl = 119,
+  /** The _LARGE version of the standard POSTFIELDSIZE option */
+  postfieldsize_large = 30120,
+  /** Enable/disable the TCP Nagle algorithm */
+  tcp_nodelay = 121,
+  /** 122 OBSOLETE, used in 7.12.3. Gone in 7.13.0 */
+  /** 123 OBSOLETE. Gone in 7.16.0 */
+  /** 124 OBSOLETE, used in 7.12.3. Gone in 7.13.0 */
+  /** 125 OBSOLETE, used in 7.12.3. Gone in 7.13.0 */
+  /** 126 OBSOLETE, used in 7.12.3. Gone in 7.13.0 */
+  /** 127 OBSOLETE. Gone in 7.16.0 */
+  /** 128 OBSOLETE. Gone in 7.16.0 */
+
+  /** When FTP over SSL/TLS is selected (with CURLOPT_USE_SSL), this option
+     can be used to change libcurl's default action which is to first try
+     "AUTH SSL" and then "AUTH TLS" in this order, and proceed when a OK
+     response has been received.
+
+     Available parameters are:
+     CURLFTPAUTH_DEFAULT - let libcurl decide
+     CURLFTPAUTH_SSL     - try "AUTH SSL" first, then TLS
+     CURLFTPAUTH_TLS     - try "AUTH TLS" first, then SSL
+  */
+  ftpsslauth = 129,
+  ioctlfunction = 20130,        ///
+  ioctldata = 10131,            ///
+  /** 132 OBSOLETE. Gone in 7.16.0 */
+  /** 133 OBSOLETE. Gone in 7.16.0 */
+
+  /** zero terminated string for pass on to the FTP server when asked for
+     "account" info */
+  ftp_account = 10134,
+  /** feed cookies into cookie engine */
+  cookielist,
+  /** ignore Content-Length */
+  ignore_content_length = 136,
+  /** Set to non-zero to skip the IP address received in a 227 PASV FTP server
+     response. Typically used for FTP-SSL purposes but is not restricted to
+     that. libcurl will then instead use the same IP address it used for the
+     control connection. */
+  ftp_skip_pasv_ip,
+  /** Select "file method" to use when doing FTP, see the curl_ftpmethod
+     above. */
+  ftp_filemethod,
+  /** Local port number to bind the socket to */
+  localport,
+  /** Number of ports to try, including the first one set with LOCALPORT.
+     Thus, setting it to 1 will make no additional attempts but the first.
+  */
+  localportrange,
+  /** no transfer, set up connection and let application use the socket by
+     extracting it with CURLINFO_LASTSOCKET */
+  connect_only,
+  /** Function that will be called to convert from the
+     network encoding (instead of using the iconv calls in libcurl) */
+  conv_from_network_function = 20142,
+  /** Function that will be called to convert to the
+     network encoding (instead of using the iconv calls in libcurl) */
+  conv_to_network_function,
+  /** Function that will be called to convert from UTF8
+     (instead of using the iconv calls in libcurl)
+     Note that this is used only for SSL certificate processing */
+  conv_from_utf8_function,
+  /** if the connection proceeds too quickly then need to slow it down */
+  /** limit-rate: maximum number of bytes per second to send or receive */
+  max_send_speed_large = 30145,
+  max_recv_speed_large, /// ditto
+  /** Pointer to command string to send if USER/PASS fails. */
+  ftp_alternative_to_user = 10147,
+  /** callback function for setting socket options */
+  sockoptfunction = 20148,
+  sockoptdata = 10149,
+  /** set to 0 to disable session ID re-use for this transfer, default is
+     enabled (== 1) */
+  ssl_sessionid_cache = 150,
+  /** allowed SSH authentication methods */
+  ssh_auth_types,
+  /** Used by scp/sftp to do public/private key authentication */
+  ssh_public_keyfile = 10152,
+  ssh_private_keyfile,
+  /** Send CCC (Clear Command Channel) after authentication */
+  ftp_ssl_ccc = 154,
+  /** Same as TIMEOUT and CONNECTTIMEOUT, but with ms resolution */
+  timeout_ms,
+  connecttimeout_ms,
+  /** set to zero to disable the libcurl's decoding and thus pass the raw body
+     data to the application even when it is encoded/compressed */
+  http_transfer_decoding,
+  http_content_decoding,        /// ditto
+  /** Permission used when creating new files and directories on the remote
+     server for protocols that support it, SFTP/SCP/FILE */
+  new_file_perms,
+  new_directory_perms,          /// ditto
+  /** Set the behaviour of POST when redirecting. Values must be set to one
+     of CURL_REDIR* defines below. This used to be called CURLOPT_POST301 */
+  postredir,
+  /** used by scp/sftp to verify the host's public key */
+  ssh_host_public_key_md5 = 10162,
+  /** Callback function for opening socket (instead of socket(2)). Optionally,
+     callback is able change the address or refuse to connect returning
+     CURL_SOCKET_BAD.  The callback should have type
+     curl_opensocket_callback */
+  opensocketfunction = 20163,
+  opensocketdata = 10164,       /// ditto
+  /** POST volatile input fields. */
+  copypostfields,
+  /** set transfer mode (;type=<a|i>) when doing FTP via an HTTP proxy */
+  proxy_transfer_mode = 166,
+  /** Callback function for seeking in the input stream */
+  seekfunction = 20167,
+  seekdata = 10168,     /// ditto
+  /** CRL file */
+  crlfile,
+  /** Issuer certificate */
+  issuercert,
+  /** (IPv6) Address scope */
+  address_scope = 171,
+  /** Collect certificate chain info and allow it to get retrievable with
+     CURLINFO_CERTINFO after the transfer is complete. (Unfortunately) only
+     working with OpenSSL-powered builds. */
+  certinfo,
+  /** "name" and "pwd" to use when fetching. */
+  username = 10173,
+  password,     /// ditto
+  /** "name" and "pwd" to use with Proxy when fetching. */
+  proxyusername,
+  proxypassword,        /// ditto
+  /** Comma separated list of hostnames defining no-proxy zones. These should
+     match both hostnames directly, and hostnames within a domain. For
+     example, local.com will match local.com and www.local.com, but NOT
+     notlocal.com or www.notlocal.com. For compatibility with other
+     implementations of this, .local.com will be considered to be the same as
+     local.com. A single * is the only valid wildcard, and effectively
+     disables the use of proxy. */
+  noproxy,
+  /** block size for TFTP transfers */
+  tftp_blksize = 178,
+  /** Socks Service */
+  socks5_gssapi_service = 10179,
+  /** Socks Service */
+  socks5_gssapi_nec = 180,
+  /** set the bitmask for the protocols that are allowed to be used for the
+     transfer, which thus helps the app which takes URLs from users or other
+     external inputs and want to restrict what protocol(s) to deal
+     with. Defaults to CURLPROTO_ALL. */
+  protocols,
+  /** set the bitmask for the protocols that libcurl is allowed to follow to,
+     as a subset of the CURLOPT_PROTOCOLS ones. That means the protocol needs
+     to be set in both bitmasks to be allowed to get redirected to. Defaults
+     to all protocols except FILE and SCP. */
+  redir_protocols,
+  /** set the SSH knownhost file name to use */
+  ssh_knownhosts = 10183,
+  /** set the SSH host key callback, must point to a curl_sshkeycallback
+     function */
+  ssh_keyfunction = 20184,
+  /** set the SSH host key callback custom pointer */
+  ssh_keydata = 10185,
+  /** set the SMTP mail originator */
+  mail_from,
+  /** set the SMTP mail receiver(s) */
+  mail_rcpt,
+  /** FTP: send PRET before PASV */
+  ftp_use_pret = 188,
+  /** RTSP request method (OPTIONS, SETUP, PLAY, etc...) */
+  rtsp_request,
+  /** The RTSP session identifier */
+  rtsp_session_id = 10190,
+  /** The RTSP stream URI */
+  rtsp_stream_uri,
+  /** The Transport: header to use in RTSP requests */
+  rtsp_transport,
+  /** Manually initialize the client RTSP CSeq for this handle */
+  rtsp_client_cseq = 193,
+  /** Manually initialize the server RTSP CSeq for this handle */
+  rtsp_server_cseq,
+  /** The stream to pass to INTERLEAVEFUNCTION. */
+  interleavedata = 10195,
+  /** Let the application define a custom write method for RTP data */
+  interleavefunction = 20196,
+  /** Turn on wildcard matching */
+  wildcardmatch = 197,
+  /** Directory matching callback called before downloading of an
+     individual file (chunk) started */
+  chunk_bgn_function = 20198,
+  /** Directory matching callback called after the file (chunk)
+     was downloaded, or skipped */
+  chunk_end_function,
+  /** Change match (fnmatch-like) callback for wildcard matching */
+  fnmatch_function,
+  /** Let the application define custom chunk data pointer */
+  chunk_data = 10201,
+  /** FNMATCH_FUNCTION user pointer */
+  fnmatch_data,
+  /** send linked-list of name:port:address sets */
+  resolve,
+  /** Set a username for authenticated TLS */
+  tlsauth_username,
+  /** Set a password for authenticated TLS */
+  tlsauth_password,
+  /** Set authentication type for authenticated TLS */
+  tlsauth_type,
+  /** the last unused */
+  lastentry,
+
+  writedata = file, /// convenient alias
+  readdata = infile, /// ditto
+  headerdata = writeheader, /// ditto
+  rtspheader = httpheader, /// ditto
+}
+///
+alias int CURLoption;
+///
+enum CURLOPT_SERVER_RESPONSE_TIMEOUT = CurlOption.ftp_response_timeout;
+
+/** Below here follows defines for the CURLOPT_IPRESOLVE option. If a host
+   name resolves addresses using more than one IP protocol version, this
+   option might be handy to force libcurl to use a specific IP version. */
+enum CurlIpResolve {
+  whatever = 0, /** default, resolves addresses to all IP versions that your system allows */
+  v4 = 1,       /** resolve to ipv4 addresses */
+  v6 = 2        /** resolve to ipv6 addresses */
+}
+
+/** three convenient "aliases" that follow the name scheme better */
+enum CURLOPT_WRITEDATA = CurlOption.file;
+/// ditto
+enum CURLOPT_READDATA = CurlOption.infile;
+/// ditto
+enum CURLOPT_HEADERDATA = CurlOption.writeheader;
+/// ditto
+enum CURLOPT_RTSPHEADER = CurlOption.httpheader;
+
+/** These enums are for use with the CURLOPT_HTTP_VERSION option. */
+enum CurlHttpVersion {
+    none, /** setting this means we don't care, and that we'd
+             like the library to choose the best possible
+             for us! */
+    v1_0, /** please use HTTP 1.0 in the request */
+    v1_1, /** please use HTTP 1.1 in the request */
+    last  /** *ILLEGAL* http version */
+}
+
+/**
+ * Public API enums for RTSP requests
+ */
+enum CurlRtspReq {
+    none,       ///
+    options,    ///
+    describe,   ///
+    announce,   ///
+    setup,      ///
+    play,       ///
+    pause,      ///
+    teardown,   ///
+    get_parameter,      ///
+    set_parameter,      ///
+    record,     ///
+    receive,    ///
+    last        ///
+}
+
+ /** These enums are for use with the CURLOPT_NETRC option. */
+enum CurlNetRcOption {
+    ignored,  /** The .netrc will never be read. This is the default. */
+    optional  /** A user:password in the URL will be preferred to one in the .netrc. */,
+    required, /** A user:password in the URL will be ignored.
+               * Unless one is set programmatically, the .netrc
+               * will be queried. */
+    last        ///
+}
+
+///
+enum CurlSslVersion {
+    default_version,    ///
+    tlsv1,      ///
+    sslv2,      ///
+    sslv3,      ///
+    last /** never use */
+}
+
+///
+enum CurlTlsAuth {
+    none,       ///
+    srp,        ///
+    last /** never use */
+}
+
+/** symbols to use with CURLOPT_POSTREDIR.
+   CURL_REDIR_POST_301 and CURL_REDIR_POST_302 can be bitwise ORed so that
+   CURL_REDIR_POST_301 | CURL_REDIR_POST_302 == CURL_REDIR_POST_ALL */
+enum CurlRedir {
+  get_all = 0,  ///
+  post_301 = 1, ///
+  post_302 = 2, ///
+  ///
+  post_all = (1 | 2) // (CURL_REDIR_POST_301|CURL_REDIR_POST_302);
+}
+///
+enum CurlTimeCond {
+    none,       ///
+    ifmodsince, ///
+    ifunmodsince,       ///
+    lastmod,    ///
+    last        ///
+}
+///
+alias int curl_TimeCond;
+
+
+/** curl_strequal() and curl_strnequal() are subject for removal in a future
+   libcurl, see lib/README.curlx for details */
+extern (C) {
+int  curl_strequal(in char *s1, in char *s2);
+/// ditto
+int  curl_strnequal(in char *s1, in char *s2, size_t n);
+}
+enum CurlForm {
+    nothing, /********** the first one is unused ************/
+    copyname,
+    ptrname,
+    namelength,
+    copycontents,
+    ptrcontents,
+    contentslength,
+    filecontent,
+    array,
+    obsolete,
+    file,
+    buffer,
+    bufferptr,
+    bufferlength,
+    contenttype,
+    contentheader,
+    filename,
+    end,
+    obsolete2,
+    stream,
+    lastentry /** the last unused */
+}
+alias int CURLformoption;
+
+
+/** structure to be used as parameter for CURLFORM_ARRAY */
+extern (C) struct curl_forms
+{
+    CURLformoption option;      ///
+    const(char) *value;        ///
+}
+
+/** use this for multipart formpost building */
+/** Returns code for curl_formadd()
+ *
+ * Returns:
+ * CURL_FORMADD_OK             on success
+ * CURL_FORMADD_MEMORY         if the FormInfo allocation fails
+ * CURL_FORMADD_OPTION_TWICE   if one option is given twice for one Form
+ * CURL_FORMADD_NULL           if a null pointer was given for a char
+ * CURL_FORMADD_MEMORY         if the allocation of a FormInfo struct failed
+ * CURL_FORMADD_UNKNOWN_OPTION if an unknown option was used
+ * CURL_FORMADD_INCOMPLETE     if the some FormInfo is not complete (or error)
+ * CURL_FORMADD_MEMORY         if a curl_httppost struct cannot be allocated
+ * CURL_FORMADD_MEMORY         if some allocation for string copying failed.
+ * CURL_FORMADD_ILLEGAL_ARRAY  if an illegal option is used in an array
+ *
+ ***************************************************************************/
+enum CurlFormAdd {
+    ok, /** first, no error */
+    memory,     ///
+    option_twice,       ///
+    null_ptr,   ///
+    unknown_option,     ///
+    incomplete, ///
+    illegal_array,      ///
+    disabled,  /** libcurl was built with this disabled */
+    last        ///
+}
+///
+alias int CURLFORMcode;
+
+extern (C) {
+
+/**
+ * Name: curl_formadd()
+ *
+ * Description:
+ *
+ * Pretty advanced function for building multi-part formposts. Each invoke
+ * adds one part that together construct a full post. Then use
+ * CURLOPT_HTTPPOST to send it off to libcurl.
+ */
+CURLFORMcode  curl_formadd(curl_httppost **httppost, curl_httppost **last_post,...);
+
+/**
+ * callback function for curl_formget()
+ * The void *arg pointer will be the one passed as second argument to
+ *   curl_formget().
+ * The character buffer passed to it must not be freed.
+ * Should return the buffer length passed to it as the argument "len" on
+ *   success.
+ */
+alias size_t  function(void *arg, in char *buf, size_t len)curl_formget_callback;
+
+/**
+ * Name: curl_formget()
+ *
+ * Description:
+ *
+ * Serialize a curl_httppost struct built with curl_formadd().
+ * Accepts a void pointer as second argument which will be passed to
+ * the curl_formget_callback function.
+ * Returns 0 on success.
+ */
+int  curl_formget(curl_httppost *form, void *arg, curl_formget_callback append);
+/**
+ * Name: curl_formfree()
+ *
+ * Description:
+ *
+ * Free a multipart formpost previously built with curl_formadd().
+ */
+void  curl_formfree(curl_httppost *form);
+
+/**
+ * Name: curl_getenv()
+ *
+ * Description:
+ *
+ * Returns a malloc()'ed string that MUST be curl_free()ed after usage is
+ * complete. DEPRECATED - see lib/README.curlx
+ */
+char * curl_getenv(in char *variable);
+
+/**
+ * Name: curl_version()
+ *
+ * Description:
+ *
+ * Returns a static ascii string of the libcurl version.
+ */
+char * curl_version();
+
+/**
+ * Name: curl_easy_escape()
+ *
+ * Description:
+ *
+ * Escapes URL strings (converts all letters consider illegal in URLs to their
+ * %XX versions). This function returns a new allocated string or NULL if an
+ * error occurred.
+ */
+char * curl_easy_escape(CURL *handle, in char *string, int length) @trusted;
+
+/** the previous version: */
+char * curl_escape(in char *string, int length) @trusted;
+
+
+/**
+ * Name: curl_easy_unescape()
+ *
+ * Description:
+ *
+ * Unescapes URL encoding in strings (converts all %XX codes to their 8bit
+ * versions). This function returns a new allocated string or NULL if an error
+ * occurred.
+ * Conversion Note: On non-ASCII platforms the ASCII %XX codes are
+ * converted into the host encoding.
+ */
+char * curl_easy_unescape(CURL *handle, in char *string, int length, int *outlength) @trusted;
+
+/** the previous version */
+char * curl_unescape(in char *string, int length) @trusted;
+
+/**
+ * Name: curl_free()
+ *
+ * Description:
+ *
+ * Provided for de-allocation in the same translation unit that did the
+ * allocation. Added in libcurl 7.10
+ */
+void  curl_free(void *p);
+
+/**
+ * Name: curl_global_init()
+ *
+ * Description:
+ *
+ * curl_global_init() should be invoked exactly once for each application that
+ * uses libcurl and before any call of other libcurl functions.
+ *
+ * This function is not thread-safe!
+ */
+CURLcode  curl_global_init(c_long flags);
+
+/**
+ * Name: curl_global_init_mem()
+ *
+ * Description:
+ *
+ * curl_global_init() or curl_global_init_mem() should be invoked exactly once
+ * for each application that uses libcurl.  This function can be used to
+ * initialize libcurl and set user defined memory management callback
+ * functions.  Users can implement memory management routines to check for
+ * memory leaks, check for mis-use of the curl library etc.  User registered
+ * callback routines with be invoked by this library instead of the system
+ * memory management routines like malloc, free etc.
+ */
+CURLcode  curl_global_init_mem(c_long flags, curl_malloc_callback m, curl_free_callback f, curl_realloc_callback r, curl_strdup_callback s, curl_calloc_callback c);
+
+/**
+ * Name: curl_global_cleanup()
+ *
+ * Description:
+ *
+ * curl_global_cleanup() should be invoked exactly once for each application
+ * that uses libcurl
+ */
+void  curl_global_cleanup();
+}
+
+/** linked-list structure for the CURLOPT_QUOTE option (and other) */
+extern (C) {
+
+struct curl_slist
+{
+    char *data;
+    curl_slist *next;
+}
+
+/**
+ * Name: curl_slist_append()
+ *
+ * Description:
+ *
+ * Appends a string to a linked list. If no list exists, it will be created
+ * first. Returns the new list, after appending.
+ */
+curl_slist * curl_slist_append(curl_slist *, in char *);
+
+/**
+ * Name: curl_slist_free_all()
+ *
+ * Description:
+ *
+ * free a previously built curl_slist.
+ */
+void  curl_slist_free_all(curl_slist *);
+
+/**
+ * Name: curl_getdate()
+ *
+ * Description:
+ *
+ * Returns the time, in seconds since 1 Jan 1970 of the time string given in
+ * the first argument. The time argument in the second parameter is unused
+ * and should be set to NULL.
+ */
+time_t  curl_getdate(char *p, time_t *unused);
+
+/** info about the certificate chain, only for OpenSSL builds. Asked
+   for with CURLOPT_CERTINFO / CURLINFO_CERTINFO */
+struct curl_certinfo
+{
+    int num_of_certs;      /** number of certificates with information */
+    curl_slist **certinfo; /** for each index in this array, there's a
+                              linked list with textual information in the
+                              format "name: value" */
+}
+
+} // extern (C) end
+
+///
+enum CURLINFO_STRING = 0x100000;
+///
+enum CURLINFO_LONG = 0x200000;
+///
+enum CURLINFO_DOUBLE = 0x300000;
+///
+enum CURLINFO_SLIST = 0x400000;
+///
+enum CURLINFO_MASK = 0x0fffff;
+
+///
+enum CURLINFO_TYPEMASK = 0xf00000;
+
+///
+enum CurlInfo {
+    none,       ///
+    effective_url = 1048577,    ///
+    response_code = 2097154,    ///
+    total_time = 3145731,       ///
+    namelookup_time,    ///
+    connect_time,       ///
+    pretransfer_time,   ///
+    size_upload,        ///
+    size_download,      ///
+    speed_download,     ///
+    speed_upload,       ///
+    header_size = 2097163,      ///
+    request_size,       ///
+    ssl_verifyresult,   ///
+    filetime,   ///
+    content_length_download = 3145743,  ///
+    content_length_upload,      ///
+    starttransfer_time, ///
+    content_type = 1048594,     ///
+    redirect_time = 3145747,    ///
+    redirect_count = 2097172,   ///
+    private_info = 1048597,     ///
+    http_connectcode = 2097174, ///
+    httpauth_avail,     ///
+    proxyauth_avail,    ///
+    os_errno,   ///
+    num_connects,       ///
+    ssl_engines = 4194331,      ///
+    cookielist, ///
+    lastsocket = 2097181,       ///
+    ftp_entry_path = 1048606,   ///
+    redirect_url,       ///
+    primary_ip, ///
+    appconnect_time = 3145761,  ///
+    certinfo = 4194338, ///
+    condition_unmet = 2097187,  ///
+    rtsp_session_id = 1048612,  ///
+    rtsp_client_cseq = 2097189, ///
+    rtsp_server_cseq,   ///
+    rtsp_cseq_recv,     ///
+    primary_port,       ///
+    local_ip = 1048617, ///
+    local_port = 2097194,       ///
+    /** Fill in new entries below here! */
+    lastone = 42
+}
+///
+alias int CURLINFO;
+
+/** CURLINFO_RESPONSE_CODE is the new name for the option previously known as
+   CURLINFO_HTTP_CODE */
+enum CURLINFO_HTTP_CODE = CurlInfo.response_code;
+
+///
+enum CurlClosePolicy {
+    none,       ///
+    oldest,     ///
+    least_recently_used,        ///
+    least_traffic,      ///
+    slowest,    ///
+    callback,   ///
+    last        ///
+}
+///
+alias int curl_closepolicy;
+
+///
+enum CurlGlobal {
+  ssl = 1,      ///
+  win32 = 2,    ///
+  ///
+  all = (1 | 2), // (CURL_GLOBAL_SSL|CURL_GLOBAL_WIN32);
+  nothing = 0,  ///
+  default_ = (1 | 2) /// all
+}
+
+/******************************************************************************
+ * Setup defines, protos etc for the sharing stuff.
+ */
+
+/** Different data locks for a single share */
+enum CurlLockData {
+    none,       ///
+    /**  CURL_LOCK_DATA_SHARE is used internally to say that
+     *  the locking is just made to change the internal state of the share
+     *  itself.
+     */
+    share,
+    cookie,     ///
+    dns,        ///
+    ssl_session,        ///
+    connect,    ///
+    last        ///
+}
+///
+alias int curl_lock_data;
+
+/** Different lock access types */
+enum CurlLockAccess {
+    none,            /** unspecified action */
+    shared_access,   /** for read perhaps */
+    single,          /** for write perhaps */
+    last             /** never use */
+}
+///
+alias int curl_lock_access;
+
+///
+alias void  function(CURL *handle, curl_lock_data data, curl_lock_access locktype, void *userptr)curl_lock_function;
+///
+alias void  function(CURL *handle, curl_lock_data data, void *userptr)curl_unlock_function;
+
+///
+alias void CURLSH;
+
+///
+enum CurlShError {
+    ok,          /** all is fine */
+    bad_option,  /** 1 */
+    in_use,      /** 2 */
+    invalid,     /** 3 */
+    nomem,       /** out of memory */
+    last         /** never use */
+}
+///
+alias int CURLSHcode;
+
+/** pass in a user data pointer used in the lock/unlock callback
+   functions */
+enum CurlShOption {
+    none,         /** don't use */
+    share,        /** specify a data type to share */
+    unshare,      /** specify which data type to stop sharing */
+    lockfunc,     /** pass in a 'curl_lock_function' pointer */
+    unlockfunc,   /** pass in a 'curl_unlock_function' pointer */
+    userdata,     /** pass in a user data pointer used in the lock/unlock
+                     callback functions */
+    last          /** never use */
+}
+///
+alias int CURLSHoption;
+
+extern (C) {
+///
+CURLSH * curl_share_init();
+///
+CURLSHcode  curl_share_setopt(CURLSH *, CURLSHoption option,...);
+///
+CURLSHcode  curl_share_cleanup(CURLSH *);
+}
+
+/*****************************************************************************
+ * Structures for querying information about the curl library at runtime.
+ */
+
+// CURLVERSION_*
+enum CurlVer {
+    first,      ///
+    second,     ///
+    third,      ///
+    fourth,     ///
+    last        ///
+}
+///
+alias int CURLversion;
+
+/** The 'CURLVERSION_NOW' is the symbolic name meant to be used by
+   basically all programs ever that want to get version information. It is
+   meant to be a built-in version number for what kind of struct the caller
+   expects. If the struct ever changes, we redefine the NOW to another enum
+   from above. */
+enum CURLVERSION_NOW = CurlVer.fourth;
+
+///
+extern (C) struct _N28
+{
+  CURLversion age;     /** age of the returned struct */
+  const(char) *version_;      /** LIBCURL_VERSION */
+  uint version_num;    /** LIBCURL_VERSION_NUM */
+  const(char) *host;          /** OS/host/cpu/machine when configured */
+  int features;        /** bitmask, see defines below */
+  const(char) *ssl_version;   /** human readable string */
+  c_long ssl_version_num; /** not used anymore, always 0 */
+  const(char) *libz_version;     /** human readable string */
+  /** protocols is terminated by an entry with a NULL protoname */
+  const(char) **protocols;
+  /** The fields below this were added in CURLVERSION_SECOND */
+  const(char) *ares;
+  int ares_num;
+  /** This field was added in CURLVERSION_THIRD */
+  const(char) *libidn;
+  /** These field were added in CURLVERSION_FOURTH */
+  /** Same as '_libiconv_version' if built with HAVE_ICONV */
+  int iconv_ver_num;
+  const(char) *libssh_version;  /** human readable string */
+}
+///
+alias _N28 curl_version_info_data;
+
+///
+// CURL_VERSION_*
+enum CurlVersion {
+  ipv6         = 1,     /** IPv6-enabled */
+  kerberos4    = 2,     /** kerberos auth is supported */
+  ssl          = 4,     /** SSL options are present */
+  libz         = 8,     /** libz features are present */
+  ntlm         = 16,    /** NTLM auth is supported */
+  gssnegotiate = 32,    /** Negotiate auth support */
+  dbg          = 64,    /** built with debug capabilities */
+  asynchdns    = 128,   /** asynchronous dns resolves */
+  spnego       = 256,   /** SPNEGO auth */
+  largefile    = 512,   /** supports files bigger than 2GB */
+  idn          = 1024,  /** International Domain Names support */
+  sspi         = 2048,  /** SSPI is supported */
+  conv         = 4096,  /** character conversions supported */
+  curldebug    = 8192,  /** debug memory tracking supported */
+  tlsauth_srp  = 16384  /** TLS-SRP auth is supported */
+}
+
+extern (C) {
+/**
+ * Name: curl_version_info()
+ *
+ * Description:
+ *
+ * This function returns a pointer to a static copy of the version info
+ * struct. See above.
+ */
+curl_version_info_data * curl_version_info(CURLversion );
+
+/**
+ * Name: curl_easy_strerror()
+ *
+ * Description:
+ *
+ * The curl_easy_strerror function may be used to turn a CURLcode value
+ * into the equivalent human readable error string.  This is useful
+ * for printing meaningful error messages.
+ */
+const(char)* curl_easy_strerror(CURLcode );
+
+/**
+ * Name: curl_share_strerror()
+ *
+ * Description:
+ *
+ * The curl_share_strerror function may be used to turn a CURLSHcode value
+ * into the equivalent human readable error string.  This is useful
+ * for printing meaningful error messages.
+ */
+const(char)* curl_share_strerror(CURLSHcode );
+
+/**
+ * Name: curl_easy_pause()
+ *
+ * Description:
+ *
+ * The curl_easy_pause function pauses or unpauses transfers. Select the new
+ * state by setting the bitmask, use the convenience defines below.
+ *
+ */
+CURLcode  curl_easy_pause(CURL *handle, int bitmask);
+}
+
+
+///
+enum CurlPause {
+  recv      = 1,        ///
+  recv_cont = 0,        ///
+  send      = 4,        ///
+  send_cont = 0,        ///
+  ///
+  all       = (1 | 4), // CURLPAUSE_RECV | CURLPAUSE_SEND
+  ///
+  cont      = (0 | 0), // CURLPAUSE_RECV_CONT | CURLPAUSE_SEND_CONT
+}
+
+/* unfortunately, the easy.h and multi.h include files need options and info
+  stuff before they can be included! */
+/* ***************************************************************************
+ *                                  _   _ ____  _
+ *  Project                     ___| | | |  _ \| |
+ *                             / __| | | | |_) | |
+ *                            | (__| |_| |  _ <| |___
+ *                             \___|\___/|_| \_\_____|
+ *
+ * Copyright (C) 1998 - 2008, Daniel Stenberg, <daniel@haxx.se>, et al.
+ *
+ * This software is licensed as described in the file COPYING, which
+ * you should have received as part of this distribution. The terms
+ * are also available at http://curl.haxx.se/docs/copyright.html.
+ *
+ * You may opt to use, copy, modify, merge, publish, distribute and/or sell
+ * copies of the Software, and permit persons to whom the Software is
+ * furnished to do so, under the terms of the COPYING file.
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTY OF ANY
+ * KIND, either express or implied.
+ *
+ ***************************************************************************/
+
+extern (C) {
+  ///
+  CURL * curl_easy_init();
+  ///
+  CURLcode  curl_easy_setopt(CURL *curl, CURLoption option,...);
+  ///
+  CURLcode  curl_easy_perform(CURL *curl);
+  ///
+  void  curl_easy_cleanup(CURL *curl);
+}
+
+/**
+ * Name: curl_easy_getinfo()
+ *
+ * Description:
+ *
+ * Request internal information from the curl session with this function.  The
+ * third argument MUST be a pointer to a long, a pointer to a char * or a
+ * pointer to a double (as the documentation describes elsewhere).  The data
+ * pointed to will be filled in accordingly and can be relied upon only if the
+ * function returns CURLE_OK.  This function is intended to get used *AFTER* a
+ * performed transfer, all results from this function are undefined until the
+ * transfer is completed.
+ */
+extern (C) CURLcode  curl_easy_getinfo(CURL *curl, CURLINFO info,...);
+
+
+/**
+ * Name: curl_easy_duphandle()
+ *
+ * Description:
+ *
+ * Creates a new curl session handle with the same options set for the handle
+ * passed in. Duplicating a handle could only be a matter of cloning data and
+ * options, internal state info and things like persistant connections cannot
+ * be transfered. It is useful in multithreaded applications when you can run
+ * curl_easy_duphandle() for each new thread to avoid a series of identical
+ * curl_easy_setopt() invokes in every thread.
+ */
+extern (C) CURL * curl_easy_duphandle(CURL *curl);
+
+/**
+ * Name: curl_easy_reset()
+ *
+ * Description:
+ *
+ * Re-initializes a CURL handle to the default values. This puts back the
+ * handle to the same state as it was in when it was just created.
+ *
+ * It does keep: live connections, the Session ID cache, the DNS cache and the
+ * cookies.
+ */
+extern (C) void  curl_easy_reset(CURL *curl);
+
+/**
+ * Name: curl_easy_recv()
+ *
+ * Description:
+ *
+ * Receives data from the connected socket. Use after successful
+ * curl_easy_perform() with CURLOPT_CONNECT_ONLY option.
+ */
+extern (C) CURLcode  curl_easy_recv(CURL *curl, void *buffer, size_t buflen, size_t *n);
+
+/**
+ * Name: curl_easy_send()
+ *
+ * Description:
+ *
+ * Sends data over the connected socket. Use after successful
+ * curl_easy_perform() with CURLOPT_CONNECT_ONLY option.
+ */
+extern (C) CURLcode  curl_easy_send(CURL *curl, void *buffer, size_t buflen, size_t *n);
+
+
+/*
+ * This header file should not really need to include "curl.h" since curl.h
+ * itself includes this file and we expect user applications to do #include
+ * <curl/curl.h> without the need for especially including multi.h.
+ *
+ * For some reason we added this include here at one point, and rather than to
+ * break existing (wrongly written) libcurl applications, we leave it as-is
+ * but with this warning attached.
+ */
+/* ***************************************************************************
+ *                                  _   _ ____  _
+ *  Project                     ___| | | |  _ \| |
+ *                             / __| | | | |_) | |
+ *                            | (__| |_| |  _ <| |___
+ *                             \___|\___/|_| \_\_____|
+ *
+ * Copyright (C) 1998 - 2010, Daniel Stenberg, <daniel@haxx.se>, et al.
+ *
+ * This software is licensed as described in the file COPYING, which
+ * you should have received as part of this distribution. The terms
+ * are also available at http://curl.haxx.se/docs/copyright.html.
+ *
+ * You may opt to use, copy, modify, merge, publish, distribute and/or sell
+ * copies of the Software, and permit persons to whom the Software is
+ * furnished to do so, under the terms of the COPYING file.
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTY OF ANY
+ * KIND, either express or implied.
+ *
+ ***************************************************************************/
+
+///
+alias void CURLM;
+
+///
+enum CurlM {
+    call_multi_perform = -1, /** please call curl_multi_perform() or curl_multi_socket*() soon */
+    ok, ///
+    bad_handle,              /** the passed-in handle is not a valid CURLM handle */
+    bad_easy_handle,       /** an easy handle was not good/valid */
+    out_of_memory,         /** if you ever get this, you're in deep sh*t */
+    internal_error,        /** this is a libcurl bug */
+    bad_socket,            /** the passed in socket argument did not match */
+    unknown_option,        /** curl_multi_setopt() with unsupported option */
+    last,       ///
+}
+///
+alias int CURLMcode;
+
+/** just to make code nicer when using curl_multi_socket() you can now check
+   for CURLM_CALL_MULTI_SOCKET too in the same style it works for
+   curl_multi_perform() and CURLM_CALL_MULTI_PERFORM */
+enum CURLM_CALL_MULTI_SOCKET = CurlM.call_multi_perform;
+
+///
+enum CurlMsg
+{
+    none,       ///
+    done, /** This easy handle has completed. 'result' contains
+             the CURLcode of the transfer */
+    last, /** no used */
+}
+///
+alias int CURLMSG;
+
+///
+extern (C) union _N31
+{
+    void *whatever;  /** message-specific data */
+    CURLcode result; /** return code for transfer */
+}
+
+///
+extern (C) struct CURLMsg
+{
+    CURLMSG msg;        /** what this message means */
+    CURL *easy_handle;  /** the handle it concerns */
+    _N31 data;  ///
+}
+
+/**
+ * Name:    curl_multi_init()
+ *
+ * Desc:    inititalize multi-style curl usage
+ *
+ * Returns: a new CURLM handle to use in all 'curl_multi' functions.
+ */
+extern (C) CURLM * curl_multi_init();
+
+/**
+ * Name:    curl_multi_add_handle()
+ *
+ * Desc:    add a standard curl handle to the multi stack
+ *
+ * Returns: CURLMcode type, general multi error code.
+ */
+extern (C) CURLMcode  curl_multi_add_handle(CURLM *multi_handle, CURL *curl_handle);
+
+ /**
+  * Name:    curl_multi_remove_handle()
+  *
+  * Desc:    removes a curl handle from the multi stack again
+  *
+  * Returns: CURLMcode type, general multi error code.
+  */
+extern (C) CURLMcode  curl_multi_remove_handle(CURLM *multi_handle, CURL *curl_handle);
+
+ /**
+  * Name:    curl_multi_fdset()
+  *
+  * Desc:    Ask curl for its fd_set sets. The app can use these to select() or
+  *          poll() on. We want curl_multi_perform() called as soon as one of
+  *          them are ready.
+  *
+  * Returns: CURLMcode type, general multi error code.
+  */
+
+/** tmp decl */
+alias int fd_set;
+///
+extern (C) CURLMcode  curl_multi_fdset(CURLM *multi_handle, fd_set *read_fd_set, fd_set *write_fd_set, fd_set *exc_fd_set, int *max_fd);
+
+ /**
+  * Name:    curl_multi_perform()
+  *
+  * Desc:    When the app thinks there's data available for curl it calls this
+  *          function to read/write whatever there is right now. This returns
+  *          as soon as the reads and writes are done. This function does not
+  *          require that there actually is data available for reading or that
+  *          data can be written, it can be called just in case. It returns
+  *          the number of handles that still transfer data in the second
+  *          argument's integer-pointer.
+  *
+  * Returns: CURLMcode type, general multi error code. *NOTE* that this only
+  *          returns errors etc regarding the whole multi stack. There might
+  *          still have occurred problems on invidual transfers even when this
+  *          returns OK.
+  */
+extern (C) CURLMcode  curl_multi_perform(CURLM *multi_handle, int *running_handles);
+
+ /**
+  * Name:    curl_multi_cleanup()
+  *
+  * Desc:    Cleans up and removes a whole multi stack. It does not free or
+  *          touch any individual easy handles in any way. We need to define
+  *          in what state those handles will be if this function is called
+  *          in the middle of a transfer.
+  *
+  * Returns: CURLMcode type, general multi error code.
+  */
+extern (C) CURLMcode  curl_multi_cleanup(CURLM *multi_handle);
+
+/**
+ * Name:    curl_multi_info_read()
+ *
+ * Desc:    Ask the multi handle if there's any messages/informationals from
+ *          the individual transfers. Messages include informationals such as
+ *          error code from the transfer or just the fact that a transfer is
+ *          completed. More details on these should be written down as well.
+ *
+ *          Repeated calls to this function will return a new struct each
+ *          time, until a special "end of msgs" struct is returned as a signal
+ *          that there is no more to get at this point.
+ *
+ *          The data the returned pointer points to will not survive calling
+ *          curl_multi_cleanup().
+ *
+ *          The 'CURLMsg' struct is meant to be very simple and only contain
+ *          very basic informations. If more involved information is wanted,
+ *          we will provide the particular "transfer handle" in that struct
+ *          and that should/could/would be used in subsequent
+ *          curl_easy_getinfo() calls (or similar). The point being that we
+ *          must never expose complex structs to applications, as then we'll
+ *          undoubtably get backwards compatibility problems in the future.
+ *
+ * Returns: A pointer to a filled-in struct, or NULL if it failed or ran out
+ *          of structs. It also writes the number of messages left in the
+ *          queue (after this read) in the integer the second argument points
+ *          to.
+ */
+extern (C) CURLMsg * curl_multi_info_read(CURLM *multi_handle, int *msgs_in_queue);
+
+/**
+ * Name:    curl_multi_strerror()
+ *
+ * Desc:    The curl_multi_strerror function may be used to turn a CURLMcode
+ *          value into the equivalent human readable error string.  This is
+ *          useful for printing meaningful error messages.
+ *
+ * Returns: A pointer to a zero-terminated error message.
+ */
+extern (C) const(char)* curl_multi_strerror(CURLMcode );
+
+/**
+ * Name:    curl_multi_socket() and
+ *          curl_multi_socket_all()
+ *
+ * Desc:    An alternative version of curl_multi_perform() that allows the
+ *          application to pass in one of the file descriptors that have been
+ *          detected to have "action" on them and let libcurl perform.
+ *          See man page for details.
+ */
+enum CurlPoll {
+  none_ = 0,   /** jdrewsen - underscored in order not to clash with reserved D symbols */
+  in_ = 1,      ///
+  out_ = 2,     ///
+  inout_ = 3,   ///
+  remove_ = 4   ///
+}
+
+///
+alias CURL_SOCKET_BAD CURL_SOCKET_TIMEOUT;
+
+///
+enum CurlCSelect {
+  in_ = 0x01,  /** jdrewsen - underscored in order not to clash with reserved D symbols */
+  out_ = 0x02,  ///
+  err_ = 0x04   ///
+}
+
+extern (C) {
+  ///
+  alias int function(CURL *easy,                            /** easy handle */
+                     curl_socket_t s,                     /** socket */
+                     int what,                            /** see above */
+                     void *userp,                         /** private callback pointer */
+                     void *socketp)curl_socket_callback;          /** private socket pointer */
+}
+
+/**
+ * Name:    curl_multi_timer_callback
+ *
+ * Desc:    Called by libcurl whenever the library detects a change in the
+ *          maximum number of milliseconds the app is allowed to wait before
+ *          curl_multi_socket() or curl_multi_perform() must be called
+ *          (to allow libcurl's timed events to take place).
+ *
+ * Returns: The callback should return zero.
+ */
+/** private callback pointer */
+
+extern (C) {
+  alias int function(CURLM *multi,    /** multi handle */
+                     c_long timeout_ms,  /** see above */
+                     void *userp) curl_multi_timer_callback;  /** private callback pointer */
+  /// ditto
+  CURLMcode  curl_multi_socket(CURLM *multi_handle, curl_socket_t s, int *running_handles);
+  /// ditto
+  CURLMcode  curl_multi_socket_action(CURLM *multi_handle, curl_socket_t s, int ev_bitmask, int *running_handles);
+  /// ditto
+  CURLMcode  curl_multi_socket_all(CURLM *multi_handle, int *running_handles);
+}
+
+/** This macro below was added in 7.16.3 to push users who recompile to use
+   the new curl_multi_socket_action() instead of the old curl_multi_socket()
+*/
+
+/**
+ * Name:    curl_multi_timeout()
+ *
+ * Desc:    Returns the maximum number of milliseconds the app is allowed to
+ *          wait before curl_multi_socket() or curl_multi_perform() must be
+ *          called (to allow libcurl's timed events to take place).
+ *
+ * Returns: CURLM error code.
+ */
+extern (C) CURLMcode  curl_multi_timeout(CURLM *multi_handle, c_long *milliseconds);
+
+///
+enum CurlMOption {
+    socketfunction = 20001,    /** This is the socket callback function pointer */
+    socketdata = 10002,        /** This is the argument passed to the socket callback */
+    pipelining = 3,             /** set to 1 to enable pipelining for this multi handle */
+    timerfunction = 20004,     /** This is the timer callback function pointer */
+    timerdata = 10005,          /** This is the argument passed to the timer callback */
+    maxconnects = 6,            /** maximum number of entries in the connection cache */
+    lastentry   ///
+}
+///
+alias int CURLMoption;
+
+
+/**
+ * Name:    curl_multi_setopt()
+ *
+ * Desc:    Sets options for the multi handle.
+ *
+ * Returns: CURLM error code.
+ */
+extern (C) CURLMcode  curl_multi_setopt(CURLM *multi_handle, CURLMoption option,...);
+
+
+/**
+ * Name:    curl_multi_assign()
+ *
+ * Desc:    This function sets an association in the multi handle between the
+ *          given socket and a private pointer of the application. This is
+ *          (only) useful for curl_multi_socket uses.
+ *
+ * Returns: CURLM error code.
+ */
+extern (C) CURLMcode  curl_multi_assign(CURLM *multi_handle, curl_socket_t sockfd, void *sockp);

--- a/patch/std_net_curl.d
+++ b/patch/std_net_curl.d
@@ -1,0 +1,4793 @@
+// Written in the D programming language.
+
+/**
+Networking client functionality as provided by $(WEB _curl.haxx.se/libcurl,
+libcurl). The libcurl library must be installed on the system in order to use
+this module.
+
+$(SCRIPT inhibitQuickIndex = 1;)
+
+$(DIVC quickindex,
+$(BOOKTABLE ,
+$(TR $(TH Category) $(TH Functions)
+)
+$(TR $(TDNW High level) $(TD $(MYREF download) $(MYREF upload) $(MYREF get)
+$(MYREF post) $(MYREF put) $(MYREF del) $(MYREF options) $(MYREF trace)
+$(MYREF connect) $(MYREF byLine) $(MYREF byChunk)
+$(MYREF byLineAsync) $(MYREF byChunkAsync) )
+)
+$(TR $(TDNW Low level) $(TD $(MYREF HTTP) $(MYREF FTP) $(MYREF
+SMTP) )
+)
+)
+)
+
+Note:
+You may need to link to the $(B curl) library, e.g. by adding $(D "libs": ["curl"])
+to your $(B dub.json) file if you are using $(LINK2 http://code.dlang.org, DUB).
+
+Windows x86 note:
+A DMD compatible libcurl static library can be downloaded from the dlang.org
+$(LINK2 http://dlang.org/download.html, download page).
+
+Compared to using libcurl directly this module allows simpler client code for
+common uses, requires no unsafe operations, and integrates better with the rest
+of the language. Futhermore it provides <a href="std_range.html">$(D range)</a>
+access to protocols supported by libcurl both synchronously and asynchronously.
+
+A high level and a low level API are available. The high level API is built
+entirely on top of the low level one.
+
+The high level API is for commonly used functionality such as HTTP/FTP get. The
+$(LREF byLineAsync) and $(LREF byChunkAsync) provides asynchronous <a
+href="std_range.html">$(D ranges)</a> that performs the request in another
+thread while handling a line/chunk in the current thread.
+
+The low level API allows for streaming and other advanced features.
+
+$(BOOKTABLE Cheat Sheet,
+$(TR $(TH Function Name) $(TH Description)
+)
+$(LEADINGROW High level)
+$(TR $(TDNW $(LREF download)) $(TD $(D
+download("ftp.digitalmars.com/sieve.ds", "/tmp/downloaded-ftp-file"))
+downloads file from URL to file system.)
+)
+$(TR $(TDNW $(LREF upload)) $(TD $(D
+upload("/tmp/downloaded-ftp-file", "ftp.digitalmars.com/sieve.ds");)
+uploads file from file system to URL.)
+)
+$(TR $(TDNW $(LREF get)) $(TD $(D
+get("dlang.org")) returns a char[] containing the dlang.org web page.)
+)
+$(TR $(TDNW $(LREF put)) $(TD $(D
+put("dlang.org", "Hi")) returns a char[] containing
+the dlang.org web page. after a HTTP PUT of "hi")
+)
+$(TR $(TDNW $(LREF post)) $(TD $(D
+post("dlang.org", "Hi")) returns a char[] containing
+the dlang.org web page. after a HTTP POST of "hi")
+)
+$(TR $(TDNW $(LREF byLine)) $(TD $(D
+byLine("dlang.org")) returns a range of char[] containing the
+dlang.org web page.)
+)
+$(TR $(TDNW $(LREF byChunk)) $(TD $(D
+byChunk("dlang.org", 10)) returns a range of ubyte[10] containing the
+dlang.org web page.)
+)
+$(TR $(TDNW $(LREF byLineAsync)) $(TD $(D
+byLineAsync("dlang.org")) returns a range of char[] containing the dlang.org web
+ page asynchronously.)
+)
+$(TR $(TDNW $(LREF byChunkAsync)) $(TD $(D
+byChunkAsync("dlang.org", 10)) returns a range of ubyte[10] containing the
+dlang.org web page asynchronously.)
+)
+$(LEADINGROW Low level
+)
+$(TR $(TDNW $(LREF HTTP)) $(TD $(D HTTP) struct for advanced usage))
+$(TR $(TDNW $(LREF FTP)) $(TD $(D FTP) struct for advanced usage))
+$(TR $(TDNW $(LREF SMTP)) $(TD $(D SMTP) struct for advanced usage))
+)
+
+
+Example:
+---
+import std.net.curl, std.stdio;
+
+// Return a char[] containing the content specified by an URL
+auto content = get("dlang.org");
+
+// Post data and return a char[] containing the content specified by an URL
+auto content = post("mydomain.com/here.cgi", "post data");
+
+// Get content of file from ftp server
+auto content = get("ftp.digitalmars.com/sieve.ds");
+
+// Post and print out content line by line. The request is done in another thread.
+foreach (line; byLineAsync("dlang.org", "Post data"))
+    writeln(line);
+
+// Get using a line range and proxy settings
+auto client = HTTP();
+client.proxy = "1.2.3.4";
+foreach (line; byLine("dlang.org", client))
+    writeln(line);
+---
+
+For more control than the high level functions provide, use the low level API:
+
+Example:
+---
+import std.net.curl, std.stdio;
+
+// GET with custom data receivers
+auto http = HTTP("dlang.org");
+http.onReceiveHeader =
+    (in char[] key, in char[] value) { writeln(key, ": ", value); };
+http.onReceive = (ubyte[] data) { /+ drop +/ return data.length; };
+http.perform();
+---
+
+First, an instance of the reference-counted HTTP struct is created. Then the
+custom delegates are set. These will be called whenever the HTTP instance
+receives a header and a data buffer, respectively. In this simple example, the
+headers are written to stdout and the data is ignored. If the request should be
+stopped before it has finished then return something less than data.length from
+the onReceive callback. See $(LREF onReceiveHeader)/$(LREF onReceive) for more
+information. Finally the HTTP request is effected by calling perform(), which is
+synchronous.
+
+Source: $(PHOBOSSRC std/net/_curl.d)
+
+Copyright: Copyright Jonas Drewsen 2011-2012
+License: $(WEB www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
+Authors: Jonas Drewsen. Some of the SMTP code contributed by Jimmy Cao.
+
+Credits: The functionally is based on $(WEB _curl.haxx.se/libcurl, libcurl).
+         LibCurl is licensed under an MIT/X derivative license.
+*/
+/*
+         Copyright Jonas Drewsen 2011 - 2012.
+Distributed under the Boost Software License, Version 1.0.
+   (See accompanying file LICENSE_1_0.txt or copy at
+         http://www.boost.org/LICENSE_1_0.txt)
+*/
+module std.net.curl;
+
+import core.thread;
+import etc.c.curl;
+import std.algorithm;
+import std.array;
+import std.concurrency;
+import std.conv;
+import std.datetime;
+import std.encoding;
+import std.exception;
+import std.regex;
+import std.socket : InternetAddress;
+import std.stdio;
+import std.string;
+import std.traits;
+import std.typecons;
+import std.typetuple;
+
+import std.internal.cstring;
+
+public import etc.c.curl : CurlOption;
+
+version(unittest)
+{
+    // Run unit test with the PHOBOS_TEST_ALLOW_NET=1 set in order to
+    // allow net traffic
+    import std.stdio;
+    import std.range;
+    import std.process : environment;
+    import std.file : tempDir;
+    import std.path : buildPath;
+
+    import std.socket : Address, INADDR_LOOPBACK, Socket, TcpSocket;
+
+    private struct TestServer
+    {
+        string addr() { return _addr; }
+
+        void handle(void function(Socket s) dg)
+        {
+            tid.send(dg);
+        }
+
+    private:
+        string _addr;
+        Tid tid;
+
+        static void loop(shared TcpSocket listener)
+        {
+            try while (true)
+            {
+                void function(Socket) handler = void;
+                try
+                    handler = receiveOnly!(typeof(handler));
+                catch (OwnerTerminated)
+                    return;
+                handler((cast()listener).accept);
+            }
+            catch (Throwable e)
+            {
+                import core.stdc.stdlib : exit, EXIT_FAILURE;
+                stderr.writeln(e);
+                exit(EXIT_FAILURE); // Bugzilla 7018
+            }
+        }
+    }
+
+    private TestServer startServer()
+    {
+        auto sock = new TcpSocket;
+        sock.bind(new InternetAddress(INADDR_LOOPBACK, InternetAddress.PORT_ANY));
+        sock.listen(1);
+        auto addr = sock.localAddress.toString();
+        auto tid = spawn(&TestServer.loop, cast(shared)sock);
+        return TestServer(addr, tid);
+    }
+
+    private ref TestServer testServer()
+    {
+        __gshared TestServer server;
+        return initOnce!server(startServer());
+    }
+
+    private struct Request(T)
+    {
+        string hdrs;
+        immutable(T)[] bdy;
+    }
+
+    private Request!T recvReq(T=char)(Socket s)
+    {
+        ubyte[1024] tmp=void;
+        ubyte[] buf;
+
+        while (true)
+        {
+            auto nbytes = s.receive(tmp[]);
+            assert(nbytes >= 0);
+
+            immutable beg = buf.length > 3 ? buf.length - 3 : 0;
+            buf ~= tmp[0 .. nbytes];
+            auto bdy = buf[beg .. $].find(cast(ubyte[])"\r\n\r\n");
+            if (bdy.empty)
+                continue;
+
+            auto hdrs = cast(string)buf[0 .. $ - bdy.length];
+            bdy.popFrontN(4);
+            // no support for chunked transfer-encoding
+            if (auto m = hdrs.matchFirst(ctRegex!(`Content-Length: ([0-9]+)`, "i")))
+            {
+                import std.uni : asUpperCase;
+                if (hdrs.asUpperCase.canFind("EXPECT: 100-CONTINUE"))
+                    s.send(httpContinue);
+
+                size_t remain = m.captures[1].to!size_t - bdy.length;
+                while (remain)
+                {
+                    nbytes = s.receive(tmp[0 .. min(remain, $)]);
+                    assert(nbytes >= 0);
+                    buf ~= tmp[0 .. nbytes];
+                    remain -= nbytes;
+                }
+            }
+            else
+            {
+                assert(bdy.empty);
+            }
+            bdy = buf[hdrs.length + 4 .. $];
+            return typeof(return)(hdrs, cast(immutable(T)[])bdy);
+        }
+    }
+
+    private string httpOK(string msg)
+    {
+        return "HTTP/1.1 200 OK\r\n"~
+            "Content-Type: text/plain\r\n"~
+            "Content-Length: "~msg.length.to!string~"\r\n"
+            "\r\n"~
+            msg;
+    }
+
+    private string httpOK()
+    {
+        return "HTTP/1.1 200 OK\r\n"~
+            "Content-Length: 0\r\n"~
+            "\r\n";
+    }
+
+    private string httpNotFound()
+    {
+        return "HTTP/1.1 404 Not Found\r\n"~
+            "Content-Length: 0\r\n"~
+            "\r\n";
+    }
+
+    private enum httpContinue = "HTTP/1.1 100 Continue\r\n\r\n";
+}
+version(StdDdoc) import std.stdio;
+
+extern (C) void exit(int);
+
+// Default data timeout for Protocols
+private enum _defaultDataTimeout = dur!"minutes"(2);
+
+/**
+Macros:
+
+CALLBACK_PARAMS = $(TABLE ,
+    $(DDOC_PARAM_ROW
+        $(DDOC_PARAM_ID $(DDOC_PARAM dlTotal))
+        $(DDOC_PARAM_DESC total bytes to download)
+        )
+    $(DDOC_PARAM_ROW
+        $(DDOC_PARAM_ID $(DDOC_PARAM dlNow))
+        $(DDOC_PARAM_DESC currently downloaded bytes)
+        )
+    $(DDOC_PARAM_ROW
+        $(DDOC_PARAM_ID $(DDOC_PARAM ulTotal))
+        $(DDOC_PARAM_DESC total bytes to upload)
+        )
+    $(DDOC_PARAM_ROW
+        $(DDOC_PARAM_ID $(DDOC_PARAM ulNow))
+        $(DDOC_PARAM_DESC currently uploaded bytes)
+        )
+)
+*/
+
+/** Connection type used when the URL should be used to auto detect the protocol.
+  *
+  * This struct is used as placeholder for the connection parameter when calling
+  * the high level API and the connection type (HTTP/FTP) should be guessed by
+  * inspecting the URL parameter.
+  *
+  * The rules for guessing the protocol are:
+  * 1, if URL starts with ftp://, ftps:// or ftp. then FTP connection is assumed.
+  * 2, HTTP connection otherwise.
+  *
+  * Example:
+  * ---
+  * import std.net.curl;
+  * // Two requests below will do the same.
+  * string content;
+  *
+  * // Explicit connection provided
+  * content = get!HTTP("dlang.org");
+  *
+  * // Guess connection type by looking at the URL
+  * content = get!AutoProtocol("ftp://foo.com/file");
+  * // and since AutoProtocol is default this is the same as
+  * connect = get("ftp://foo.com/file");
+  * // and will end up detecting FTP from the url and be the same as
+  * connect = get!FTP("ftp://foo.com/file");
+  * ---
+  */
+struct AutoProtocol { }
+
+// Returns true if the url points to an FTP resource
+private bool isFTPUrl(const(char)[] url)
+{
+    return startsWith(url.toLower(), "ftp://", "ftps://", "ftp.") != 0;
+}
+
+// Is true if the Conn type is a valid Curl Connection type.
+private template isCurlConn(Conn)
+{
+    enum auto isCurlConn = is(Conn : HTTP) ||
+        is(Conn : FTP) || is(Conn : AutoProtocol);
+}
+
+/** HTTP/FTP download to local file system.
+ *
+ * Params:
+ * url = resource to download
+ * saveToPath = path to store the downloaded content on local disk
+ * conn = connection to use e.g. FTP or HTTP. The default AutoProtocol will
+ *        guess connection type and create a new instance for this call only.
+ *
+ * Example:
+ * ----
+ * import std.net.curl;
+ * download("d-lang.appspot.com/testUrl2", "/tmp/downloaded-http-file");
+ * ----
+ */
+void download(Conn = AutoProtocol)(const(char)[] url, string saveToPath, Conn conn = Conn())
+    if (isCurlConn!Conn)
+{
+    static if (is(Conn : HTTP) || is(Conn : FTP))
+    {
+        import std.stdio : File;
+        conn.url = url;
+        auto f = File(saveToPath, "wb");
+        conn.onReceive = (ubyte[] data) { f.rawWrite(data); return data.length; };
+        conn.perform();
+    }
+    else
+    {
+        if (isFTPUrl(url))
+            return download!FTP(url, saveToPath, FTP());
+        else
+            return download!HTTP(url, saveToPath, HTTP());
+    }
+}
+
+unittest
+{
+    foreach (host; [testServer.addr, "http://"~testServer.addr])
+    {
+        testServer.handle((s) {
+            assert(s.recvReq.hdrs.canFind("GET /"));
+            s.send(httpOK("Hello world"));
+        });
+        auto fn = buildPath(tempDir(), "downloaded-http-file");
+        scope (exit) std.file.remove(fn);
+        download(host, fn);
+        assert(std.file.readText(fn) == "Hello world");
+    }
+}
+
+/** Upload file from local files system using the HTTP or FTP protocol.
+ *
+ * Params:
+ * loadFromPath = path load data from local disk.
+ * url = resource to upload to
+ * conn = connection to use e.g. FTP or HTTP. The default AutoProtocol will
+ *        guess connection type and create a new instance for this call only.
+ *
+ * Example:
+ * ----
+ * import std.net.curl;
+ * upload("/tmp/downloaded-ftp-file", "ftp.digitalmars.com/sieve.ds");
+ * upload("/tmp/downloaded-http-file", "d-lang.appspot.com/testUrl2");
+ * ----
+ */
+void upload(Conn = AutoProtocol)(string loadFromPath, const(char)[] url, Conn conn = Conn())
+    if (isCurlConn!Conn)
+{
+    static if (is(Conn : HTTP))
+    {
+        conn.url = url;
+        conn.method = HTTP.Method.put;
+    }
+    else static if (is(Conn : FTP))
+    {
+        conn.url = url;
+        conn.handle.set(CurlOption.upload, 1L);
+    }
+    else
+    {
+        if (isFTPUrl(url))
+            return upload!FTP(loadFromPath, url, FTP());
+        else
+            return upload!HTTP(loadFromPath, url, HTTP());
+    }
+
+    static if (is(Conn : HTTP) || is(Conn : FTP))
+    {
+        auto f = File(loadFromPath, "rb");
+        conn.onSend = buf => f.rawRead(buf).length;
+        auto sz = f.size;
+        if (sz != ulong.max)
+            conn.contentLength = sz;
+        conn.perform();
+    }
+}
+
+unittest
+{
+    foreach (host; [testServer.addr, "http://"~testServer.addr])
+    {
+        auto fn = buildPath(tempDir(), "downloaded-http-file");
+        scope (exit) std.file.remove(fn);
+        std.file.write(fn, "upload data\n");
+        testServer.handle((s) {
+            auto req = s.recvReq;
+            assert(req.hdrs.canFind("PUT /path"));
+            assert(req.bdy.canFind("upload data"));
+            s.send(httpOK());
+        });
+        upload(fn, host ~ "/path");
+    }
+}
+
+/** HTTP/FTP get content.
+ *
+ * Params:
+ * url = resource to get
+ * conn = connection to use e.g. FTP or HTTP. The default AutoProtocol will
+ *        guess connection type and create a new instance for this call only.
+ *
+ * The template parameter $(D T) specifies the type to return. Possible values
+ * are $(D char) and $(D ubyte) to return $(D char[]) or $(D ubyte[]). If asking
+ * for $(D char), content will be converted from the connection character set
+ * (specified in HTTP response headers or FTP connection properties, both ISO-8859-1
+ * by default) to UTF-8.
+ *
+ * Example:
+ * ----
+ * import std.net.curl;
+ * auto content = get("d-lang.appspot.com/testUrl2");
+ * ----
+ *
+ * Returns:
+ * A T[] range containing the content of the resource pointed to by the URL.
+ *
+ * Throws:
+ *
+ * $(D CurlException) on error.
+ *
+ * See_Also: $(LREF HTTP.Method)
+ */
+T[] get(Conn = AutoProtocol, T = char)(const(char)[] url, Conn conn = Conn())
+    if ( isCurlConn!Conn && (is(T == char) || is(T == ubyte)) )
+{
+    static if (is(Conn : HTTP))
+    {
+        conn.method = HTTP.Method.get;
+        return _basicHTTP!(T)(url, "", conn);
+
+    }
+    else static if (is(Conn : FTP))
+    {
+        return _basicFTP!(T)(url, "", conn);
+    }
+    else
+    {
+        if (isFTPUrl(url))
+            return get!(FTP,T)(url, FTP());
+        else
+            return get!(HTTP,T)(url, HTTP());
+    }
+}
+
+unittest
+{
+    foreach (host; [testServer.addr, "http://"~testServer.addr])
+    {
+        testServer.handle((s) {
+            assert(s.recvReq.hdrs.canFind("GET /path"));
+            s.send(httpOK("GETRESPONSE"));
+        });
+        auto res = get(host ~ "/path");
+        assert(res == "GETRESPONSE");
+    }
+}
+
+
+/** HTTP post content.
+ *
+ * Params:
+ * url = resource to post to
+ * postData = data to send as the body of the request. An array
+ *            of an arbitrary type is accepted and will be cast to ubyte[]
+ *            before sending it.
+ * conn = HTTP connection to use
+ *
+ * The template parameter $(D T) specifies the type to return. Possible values
+ * are $(D char) and $(D ubyte) to return $(D char[]) or $(D ubyte[]). If asking
+ * for $(D char), content will be converted from the connection character set
+ * (specified in HTTP response headers or FTP connection properties, both ISO-8859-1
+ * by default) to UTF-8.
+ *
+ * Example:
+ * ----
+ * import std.net.curl;
+ * auto content = post("d-lang.appspot.com/testUrl2", [1,2,3,4]);
+ * ----
+ *
+ * Returns:
+ * A T[] range containing the content of the resource pointed to by the URL.
+ *
+ * See_Also: $(LREF HTTP.Method)
+ */
+T[] post(T = char, PostUnit)(const(char)[] url, const(PostUnit)[] postData, HTTP conn = HTTP())
+if (is(T == char) || is(T == ubyte))
+{
+    conn.method = HTTP.Method.post;
+    return _basicHTTP!(T)(url, postData, conn);
+}
+
+unittest
+{
+    foreach (host; [testServer.addr, "http://"~testServer.addr])
+    {
+        testServer.handle((s) {
+            auto req = s.recvReq;
+            assert(req.hdrs.canFind("POST /path"));
+            assert(req.bdy.canFind("POSTBODY"));
+            s.send(httpOK("POSTRESPONSE"));
+        });
+        auto res = post(host ~ "/path", "POSTBODY");
+        assert(res == "POSTRESPONSE");
+    }
+}
+
+unittest
+{
+    auto data = new ubyte[](256);
+    foreach (i, ref ub; data)
+        ub = cast(ubyte)i;
+
+    testServer.handle((s) {
+        auto req = s.recvReq!ubyte;
+        assert(req.bdy.canFind(cast(ubyte[])[0, 1, 2, 3, 4]));
+        assert(req.bdy.canFind(cast(ubyte[])[253, 254, 255]));
+        s.send(httpOK(cast(ubyte[])[17, 27, 35, 41]));
+    });
+    auto res = post!ubyte(testServer.addr, data);
+    assert(res == cast(ubyte[])[17, 27, 35, 41]);
+}
+
+
+/** HTTP/FTP put content.
+ *
+ * Params:
+ * url = resource to put
+ * putData = data to send as the body of the request. An array
+ *           of an arbitrary type is accepted and will be cast to ubyte[]
+ *           before sending it.
+ * conn = connection to use e.g. FTP or HTTP. The default AutoProtocol will
+ *        guess connection type and create a new instance for this call only.
+ *
+ * The template parameter $(D T) specifies the type to return. Possible values
+ * are $(D char) and $(D ubyte) to return $(D char[]) or $(D ubyte[]). If asking
+ * for $(D char), content will be converted from the connection character set
+ * (specified in HTTP response headers or FTP connection properties, both ISO-8859-1
+ * by default) to UTF-8.
+ *
+ * Example:
+ * ----
+ * import std.net.curl;
+ * auto content = put("d-lang.appspot.com/testUrl2",
+ *                      "Putting this data");
+ * ----
+ *
+ * Returns:
+ * A T[] range containing the content of the resource pointed to by the URL.
+ *
+ * See_Also: $(LREF HTTP.Method)
+ */
+T[] put(Conn = AutoProtocol, T = char, PutUnit)(const(char)[] url, const(PutUnit)[] putData,
+                                                  Conn conn = Conn())
+    if ( isCurlConn!Conn && (is(T == char) || is(T == ubyte)) )
+{
+    static if (is(Conn : HTTP))
+    {
+        conn.method = HTTP.Method.put;
+        return _basicHTTP!(T)(url, putData, conn);
+    }
+    else static if (is(Conn : FTP))
+    {
+        return _basicFTP!(T)(url, putData, conn);
+    }
+    else
+    {
+        if (isFTPUrl(url))
+            return put!(FTP,T)(url, putData, FTP());
+        else
+            return put!(HTTP,T)(url, putData, HTTP());
+    }
+}
+
+unittest
+{
+    foreach (host; [testServer.addr, "http://"~testServer.addr])
+    {
+        testServer.handle((s) {
+            auto req = s.recvReq;
+            assert(req.hdrs.canFind("PUT /path"));
+            assert(req.bdy.canFind("PUTBODY"));
+            s.send(httpOK("PUTRESPONSE"));
+        });
+        auto res = put(host ~ "/path", "PUTBODY");
+        assert(res == "PUTRESPONSE");
+    }
+}
+
+
+/** HTTP/FTP delete content.
+ *
+ * Params:
+ * url = resource to delete
+ * conn = connection to use e.g. FTP or HTTP. The default AutoProtocol will
+ *        guess connection type and create a new instance for this call only.
+ *
+ * Example:
+ * ----
+ * import std.net.curl;
+ * del("d-lang.appspot.com/testUrl2");
+ * ----
+ *
+ * See_Also: $(LREF HTTP.Method)
+ */
+void del(Conn = AutoProtocol)(const(char)[] url, Conn conn = Conn())
+    if (isCurlConn!Conn)
+{
+    static if (is(Conn : HTTP))
+    {
+        conn.method = HTTP.Method.del;
+        _basicHTTP!char(url, cast(void[]) null, conn);
+    }
+    else static if (is(Conn : FTP))
+    {
+        auto trimmed = url.findSplitAfter("ftp://")[1];
+        auto t = trimmed.findSplitAfter("/");
+        enum minDomainNameLength = 3;
+        enforce!CurlException(t[0].length > minDomainNameLength,
+                                text("Invalid FTP URL for delete ", url));
+        conn.url = t[0];
+
+        enforce!CurlException(!t[1].empty,
+                                text("No filename specified to delete for URL ", url));
+        conn.addCommand("DELE " ~ t[1]);
+        conn.perform();
+    }
+    else
+    {
+        if (isFTPUrl(url))
+            return del!FTP(url, FTP());
+        else
+            return del!HTTP(url, HTTP());
+    }
+}
+
+unittest
+{
+    foreach (host; [testServer.addr, "http://"~testServer.addr])
+    {
+        testServer.handle((s) {
+            auto req = s.recvReq;
+            assert(req.hdrs.canFind("DELETE /path"));
+            s.send(httpOK());
+        });
+        del(host ~ "/path");
+    }
+}
+
+
+/** HTTP options request.
+ *
+ * Params:
+ * url = resource make a option call to
+ * conn = connection to use e.g. FTP or HTTP. The default AutoProtocol will
+ *        guess connection type and create a new instance for this call only.
+ *
+ * The template parameter $(D T) specifies the type to return. Possible values
+ * are $(D char) and $(D ubyte) to return $(D char[]) or $(D ubyte[]).
+ *
+ * Example:
+ * ----
+ * import std.net.curl;
+ * auto http = HTTP();
+ * options("d-lang.appspot.com/testUrl2", http);
+ * writeln("Allow set to " ~ http.responseHeaders["Allow"]);
+ * ----
+ *
+ * Returns:
+ * A T[] range containing the options of the resource pointed to by the URL.
+ *
+ * See_Also: $(LREF HTTP.Method)
+ */
+T[] options(T = char)(const(char)[] url, HTTP conn = HTTP())
+    if (is(T == char) || is(T == ubyte))
+{
+    conn.method = HTTP.Method.options;
+    return _basicHTTP!(T)(url, null, conn);
+}
+
+deprecated("options does not send any data")
+T[] options(T = char, OptionsUnit)(const(char)[] url,
+                                   const(OptionsUnit)[] optionsData = null,
+                                   HTTP conn = HTTP())
+    if (is(T == char) || is(T == ubyte))
+{
+    return options!T(url, conn);
+}
+
+unittest
+{
+    testServer.handle((s) {
+        auto req = s.recvReq;
+        assert(req.hdrs.canFind("OPTIONS /path"));
+        s.send(httpOK("OPTIONSRESPONSE"));
+    });
+    auto res = options(testServer.addr ~ "/path");
+    assert(res == "OPTIONSRESPONSE");
+}
+
+
+/** HTTP trace request.
+ *
+ * Params:
+ * url = resource make a trace call to
+ * conn = connection to use e.g. FTP or HTTP. The default AutoProtocol will
+ *        guess connection type and create a new instance for this call only.
+ *
+ * The template parameter $(D T) specifies the type to return. Possible values
+ * are $(D char) and $(D ubyte) to return $(D char[]) or $(D ubyte[]).
+ *
+ * Example:
+ * ----
+ * import std.net.curl;
+ * trace("d-lang.appspot.com/testUrl1");
+ * ----
+ *
+ * Returns:
+ * A T[] range containing the trace info of the resource pointed to by the URL.
+ *
+ * See_Also: $(LREF HTTP.Method)
+ */
+T[] trace(T = char)(const(char)[] url, HTTP conn = HTTP())
+   if (is(T == char) || is(T == ubyte))
+{
+    conn.method = HTTP.Method.trace;
+    return _basicHTTP!(T)(url, cast(void[]) null, conn);
+}
+
+unittest
+{
+    testServer.handle((s) {
+        auto req = s.recvReq;
+        assert(req.hdrs.canFind("TRACE /path"));
+        s.send(httpOK("TRACERESPONSE"));
+    });
+    auto res = trace(testServer.addr ~ "/path");
+    assert(res == "TRACERESPONSE");
+}
+
+
+/** HTTP connect request.
+ *
+ * Params:
+ * url = resource make a connect to
+ * conn = HTTP connection to use
+ *
+ * The template parameter $(D T) specifies the type to return. Possible values
+ * are $(D char) and $(D ubyte) to return $(D char[]) or $(D ubyte[]).
+ *
+ * Example:
+ * ----
+ * import std.net.curl;
+ * connect("d-lang.appspot.com/testUrl1");
+ * ----
+ *
+ * Returns:
+ * A T[] range containing the connect info of the resource pointed to by the URL.
+ *
+ * See_Also: $(LREF HTTP.Method)
+ */
+T[] connect(T = char)(const(char)[] url, HTTP conn = HTTP())
+   if (is(T == char) || is(T == ubyte))
+{
+    conn.method = HTTP.Method.connect;
+    return _basicHTTP!(T)(url, cast(void[]) null, conn);
+}
+
+unittest
+{
+    testServer.handle((s) {
+        auto req = s.recvReq;
+        assert(req.hdrs.canFind("CONNECT /path"));
+        s.send(httpOK("CONNECTRESPONSE"));
+    });
+    auto res = connect(testServer.addr ~ "/path");
+    assert(res == "CONNECTRESPONSE");
+}
+
+
+/** HTTP patch content.
+ *
+ * Params:
+ * url = resource to patch
+ * patchData = data to send as the body of the request. An array
+ *           of an arbitrary type is accepted and will be cast to ubyte[]
+ *           before sending it.
+ * conn = HTTP connection to use
+ *
+ * The template parameter $(D T) specifies the type to return. Possible values
+ * are $(D char) and $(D ubyte) to return $(D char[]) or $(D ubyte[]).
+ *
+ * Example:
+ * ----
+ * auto http = HTTP();
+ * http.addRequestHeader("Content-Type", "application/json");
+ * auto content = patch("d-lang.appspot.com/testUrl2", `{"title": "Patched Title"}`, http);
+ * ----
+ *
+ * Returns:
+ * A T[] range containing the content of the resource pointed to by the URL.
+ *
+ * See_Also: $(LREF HTTP.Method)
+ */
+T[] patch(T = char, PatchUnit)(const(char)[] url, const(PatchUnit)[] patchData,
+                               HTTP conn = HTTP())
+    if (is(T == char) || is(T == ubyte))
+{
+    conn.method = HTTP.Method.patch;
+    return _basicHTTP!(T)(url, patchData, conn);
+}
+
+unittest
+{
+    testServer.handle((s) {
+        auto req = s.recvReq;
+        assert(req.hdrs.canFind("PATCH /path"));
+        assert(req.bdy.canFind("PATCHBODY"));
+        s.send(httpOK("PATCHRESPONSE"));
+    });
+    auto res = patch(testServer.addr ~ "/path", "PATCHBODY");
+    assert(res == "PATCHRESPONSE");
+}
+
+
+/*
+ * Helper function for the high level interface.
+ *
+ * It performs an HTTP request using the client which must have
+ * been setup correctly before calling this function.
+ */
+private auto _basicHTTP(T)(const(char)[] url, const(void)[] sendData, HTTP client)
+{
+    immutable doSend = sendData !is null &&
+        (client.method == HTTP.Method.post ||
+         client.method == HTTP.Method.put ||
+         client.method == HTTP.Method.patch);
+
+    scope (exit)
+    {
+        client.onReceiveHeader = null;
+        client.onReceiveStatusLine = null;
+        client.onReceive = null;
+
+        if (doSend)
+        {
+            client.onSend = null;
+            client.handle.onSeek = null;
+            client.contentLength = 0;
+        }
+    }
+    client.url = url;
+    HTTP.StatusLine statusLine;
+    ubyte[] content;
+    string[string] headers;
+    client.onReceive = (ubyte[] data)
+    {
+        content ~= data;
+        return data.length;
+    };
+
+    if (doSend)
+    {
+        client.contentLength = sendData.length;
+        auto remainingData = sendData;
+        client.onSend = delegate size_t(void[] buf)
+        {
+            size_t minLen = min(buf.length, remainingData.length);
+            if (minLen == 0) return 0;
+            buf[0..minLen] = remainingData[0..minLen];
+            remainingData = remainingData[minLen..$];
+            return minLen;
+        };
+        client.handle.onSeek = delegate(long offset, CurlSeekPos mode)
+        {
+            switch (mode)
+            {
+                case CurlSeekPos.set:
+                    remainingData = sendData[cast(size_t)offset..$];
+                    return CurlSeek.ok;
+                default:
+                    // As of curl 7.18.0, libcurl will not pass
+                    // anything other than CurlSeekPos.set.
+                    return CurlSeek.cantseek;
+            }
+        };
+    }
+
+    client.onReceiveHeader = (in char[] key,
+                              in char[] value)
+    {
+        if (auto v = key in headers)
+        {
+            *v ~= ", ";
+            *v ~= value;
+        }
+        else
+            headers[key] = value.idup;
+    };
+    client.onReceiveStatusLine = (HTTP.StatusLine l) { statusLine = l; };
+    client.perform();
+    enforce!CurlException(statusLine.code / 100 == 2,
+                            format("HTTP request returned status code %d (%s)",
+                                   statusLine.code, statusLine.reason));
+
+    // Default charset defined in HTTP RFC
+    auto charset = "ISO-8859-1";
+    if (auto v = "content-type" in headers)
+    {
+        auto m = match(cast(char[]) (*v), regex("charset=([^;,]*)"));
+        if (!m.empty && m.captures.length > 1)
+        {
+            charset = m.captures[1].idup;
+        }
+    }
+
+    return _decodeContent!T(content, charset);
+}
+
+unittest
+{
+    testServer.handle((s) {
+        auto req = s.recvReq;
+        assert(req.hdrs.canFind("GET /path"));
+        s.send(httpNotFound());
+    });
+    auto e = collectException!CurlException(get(testServer.addr ~ "/path"));
+    assert(e.msg == "HTTP request returned status code 404 (Not Found)");
+}
+
+// Bugzilla 14760 - content length must be reset after post
+unittest
+{
+    testServer.handle((s) {
+        auto req = s.recvReq;
+        assert(req.hdrs.canFind("POST /"));
+        assert(req.bdy.canFind("POSTBODY"));
+        s.send(httpOK("POSTRESPONSE"));
+
+        req = s.recvReq;
+        assert(req.hdrs.canFind("TRACE /"));
+        assert(req.bdy.empty);
+        s.blocking = false;
+        ubyte[6] buf = void;
+        assert(s.receive(buf[]) < 0);
+        s.send(httpOK("TRACERESPONSE"));
+    });
+    auto http = HTTP();
+    auto res = post(testServer.addr, "POSTBODY", http);
+    assert(res == "POSTRESPONSE");
+    res = trace(testServer.addr, http);
+    assert(res == "TRACERESPONSE");
+}
+
+/*
+ * Helper function for the high level interface.
+ *
+ * It performs an FTP request using the client which must have
+ * been setup correctly before calling this function.
+ */
+private auto _basicFTP(T)(const(char)[] url, const(void)[] sendData, FTP client)
+{
+    scope (exit)
+    {
+        client.onReceive = null;
+        if (!sendData.empty)
+            client.onSend = null;
+    }
+
+    ubyte[] content;
+
+    if (client.encoding.empty)
+        client.encoding = "ISO-8859-1";
+
+    client.url = url;
+    client.onReceive = (ubyte[] data)
+    {
+        content ~= data;
+        return data.length;
+    };
+
+    if (!sendData.empty)
+    {
+        client.handle.set(CurlOption.upload, 1L);
+        client.onSend = delegate size_t(void[] buf)
+        {
+            size_t minLen = min(buf.length, sendData.length);
+            if (minLen == 0) return 0;
+            buf[0..minLen] = sendData[0..minLen];
+            sendData = sendData[minLen..$];
+            return minLen;
+        };
+    }
+
+    client.perform();
+
+    return _decodeContent!T(content, client.encoding);
+}
+
+/* Used by _basicHTTP() and _basicFTP() to decode ubyte[] to
+ * correct string format
+ */
+private auto _decodeContent(T)(ubyte[] content, string encoding)
+{
+    static if (is(T == ubyte))
+    {
+        return content;
+    }
+    else
+    {
+        // Optimally just return the utf8 encoded content
+        if (encoding == "UTF-8")
+            return cast(char[])(content);
+
+        // The content has to be re-encoded to utf8
+        auto scheme = EncodingScheme.create(encoding);
+        enforce!CurlException(scheme !is null,
+                                format("Unknown encoding '%s'", encoding));
+
+        auto strInfo = decodeString(content, scheme);
+        enforce!CurlException(strInfo[0] != size_t.max,
+                                format("Invalid encoding sequence for encoding '%s'",
+                                       encoding));
+
+        return strInfo[1];
+    }
+}
+
+alias KeepTerminator = Flag!"keepTerminator";
+/+
+struct ByLineBuffer(Char)
+{
+    bool linePresent;
+    bool EOF;
+    Char[] buffer;
+    ubyte[] decodeRemainder;
+
+    bool append(const(ubyte)[] data)
+    {
+        byLineBuffer ~= data;
+    }
+
+    @property bool linePresent()
+    {
+        return byLinePresent;
+    }
+
+    Char[] get()
+    {
+        if (!linePresent)
+        {
+            // Decode ubyte[] into Char[] until a Terminator is found.
+            // If not Terminator is found and EOF is false then raise an
+            // exception.
+        }
+        return byLineBuffer;
+    }
+
+}
+++/
+/** HTTP/FTP fetch content as a range of lines.
+ *
+ * A range of lines is returned when the request is complete. If the method or
+ * other request properties is to be customized then set the $(D conn) parameter
+ * with a HTTP/FTP instance that has these properties set.
+ *
+ * Example:
+ * ----
+ * import std.net.curl, std.stdio;
+ * foreach (line; byLine("dlang.org"))
+ *     writeln(line);
+ * ----
+ *
+ * Params:
+ * url = The url to receive content from
+ * keepTerminator = KeepTerminator.yes signals that the line terminator should be
+ *                  returned as part of the lines in the range.
+ * terminator = The character that terminates a line
+ * conn = The connection to use e.g. HTTP or FTP.
+ *
+ * Returns:
+ * A range of Char[] with the content of the resource pointer to by the URL
+ */
+auto byLine(Conn = AutoProtocol, Terminator = char, Char = char)
+           (const(char)[] url, KeepTerminator keepTerminator = KeepTerminator.no,
+            Terminator terminator = '\n', Conn conn = Conn())
+if (isCurlConn!Conn && isSomeChar!Char && isSomeChar!Terminator)
+{
+    static struct SyncLineInputRange
+    {
+
+        private Char[] lines;
+        private Char[] current;
+        private bool currentValid;
+        private bool keepTerminator;
+        private Terminator terminator;
+
+        this(Char[] lines, bool kt, Terminator terminator)
+        {
+            this.lines = lines;
+            this.keepTerminator = kt;
+            this.terminator = terminator;
+            currentValid = true;
+            popFront();
+        }
+
+        @property @safe bool empty()
+        {
+            return !currentValid;
+        }
+
+        @property @safe Char[] front()
+        {
+            enforce!CurlException(currentValid, "Cannot call front() on empty range");
+            return current;
+        }
+
+        void popFront()
+        {
+            enforce!CurlException(currentValid, "Cannot call popFront() on empty range");
+            if (lines.empty)
+            {
+                currentValid = false;
+                return;
+            }
+
+            if (keepTerminator)
+            {
+                auto r = findSplitAfter(lines, [ terminator ]);
+                if (r[0].empty)
+                {
+                    current = r[1];
+                    lines = r[0];
+                }
+                else
+                {
+                    current = r[0];
+                    lines = r[1];
+                }
+            }
+            else
+            {
+                auto r = findSplit(lines, [ terminator ]);
+                current = r[0];
+                lines = r[2];
+            }
+        }
+    }
+
+    auto result = _getForRange!Char(url, conn);
+    return SyncLineInputRange(result, keepTerminator == KeepTerminator.yes, terminator);
+}
+
+unittest
+{
+    foreach (host; [testServer.addr, "http://"~testServer.addr])
+    {
+        testServer.handle((s) {
+            auto req = s.recvReq;
+            s.send(httpOK("Line1\nLine2\nLine3"));
+        });
+        assert(byLine(host).equal(["Line1", "Line2", "Line3"]));
+    }
+}
+
+/** HTTP/FTP fetch content as a range of chunks.
+ *
+ * A range of chunks is returned when the request is complete. If the method or
+ * other request properties is to be customized then set the $(D conn) parameter
+ * with a HTTP/FTP instance that has these properties set.
+ *
+ * Example:
+ * ----
+ * import std.net.curl, std.stdio;
+ * foreach (chunk; byChunk("dlang.org", 100))
+ *     writeln(chunk); // chunk is ubyte[100]
+ * ----
+ *
+ * Params:
+ * url = The url to receive content from
+ * chunkSize = The size of each chunk
+ * conn = The connection to use e.g. HTTP or FTP.
+ *
+ * Returns:
+ * A range of ubyte[chunkSize] with the content of the resource pointer to by the URL
+ */
+auto byChunk(Conn = AutoProtocol)
+            (const(char)[] url, size_t chunkSize = 1024, Conn conn = Conn())
+    if (isCurlConn!(Conn))
+{
+    static struct SyncChunkInputRange
+    {
+        private size_t chunkSize;
+        private ubyte[] _bytes;
+        private size_t offset;
+
+        this(ubyte[] bytes, size_t chunkSize)
+        {
+            this._bytes = bytes;
+            this.chunkSize = chunkSize;
+        }
+
+        @property @safe auto empty()
+        {
+            return offset == _bytes.length;
+        }
+
+        @property ubyte[] front()
+        {
+            size_t nextOffset = offset + chunkSize;
+            if (nextOffset > _bytes.length) nextOffset = _bytes.length;
+            return _bytes[offset..nextOffset];
+        }
+
+        @safe void popFront()
+        {
+            offset += chunkSize;
+            if (offset > _bytes.length) offset = _bytes.length;
+        }
+    }
+
+    auto result = _getForRange!ubyte(url, conn);
+    return SyncChunkInputRange(result, chunkSize);
+}
+
+unittest
+{
+    foreach (host; [testServer.addr, "http://"~testServer.addr])
+    {
+        testServer.handle((s) {
+            auto req = s.recvReq;
+            s.send(httpOK(cast(ubyte[])[0, 1, 2, 3, 4, 5]));
+        });
+        assert(byChunk(host, 2).equal([[0, 1], [2, 3], [4, 5]]));
+    }
+}
+
+private T[] _getForRange(T,Conn)(const(char)[] url, Conn conn)
+{
+    static if (is(Conn : HTTP))
+    {
+        conn.method = conn.method == HTTP.Method.undefined ? HTTP.Method.get : conn.method;
+        return _basicHTTP!(T)(url, null, conn);
+    }
+    else static if (is(Conn : FTP))
+    {
+        return _basicFTP!(T)(url, null, conn);
+    }
+    else
+    {
+        if (isFTPUrl(url))
+            return get!(FTP,T)(url, FTP());
+        else
+            return get!(HTTP,T)(url, HTTP());
+    }
+}
+
+/*
+  Main thread part of the message passing protocol used for all async
+  curl protocols.
+ */
+private mixin template WorkerThreadProtocol(Unit, alias units)
+{
+    @property bool empty()
+    {
+        tryEnsureUnits();
+        return state == State.done;
+    }
+
+    @property Unit[] front()
+    {
+        tryEnsureUnits();
+        assert(state == State.gotUnits,
+               format("Expected %s but got $s",
+                      State.gotUnits, state));
+        return units;
+    }
+
+    void popFront()
+    {
+        tryEnsureUnits();
+        assert(state == State.gotUnits,
+               format("Expected %s but got $s",
+                      State.gotUnits, state));
+        state = State.needUnits;
+        // Send to worker thread for buffer reuse
+        workerTid.send(cast(immutable(Unit)[]) units);
+        units = null;
+    }
+
+    /** Wait for duration or until data is available and return true if data is
+         available
+    */
+    bool wait(Duration d)
+    {
+        if (state == State.gotUnits)
+            return true;
+
+        enum noDur = dur!"hnsecs"(0);
+        StopWatch sw;
+        sw.start();
+        while (state != State.gotUnits && d > noDur)
+        {
+            final switch (state)
+            {
+            case State.needUnits:
+                receiveTimeout(d,
+                        (Tid origin, CurlMessage!(immutable(Unit)[]) _data)
+                        {
+                            if (origin != workerTid)
+                                return false;
+                            units = cast(Unit[]) _data.data;
+                            state = State.gotUnits;
+                            return true;
+                        },
+                        (Tid origin, CurlMessage!bool f)
+                        {
+                            if (origin != workerTid)
+                                return false;
+                            state = state.done;
+                            return true;
+                        }
+                        );
+                break;
+            case State.gotUnits: return true;
+            case State.done:
+                return false;
+            }
+            d -= sw.peek();
+            sw.reset();
+        }
+        return state == State.gotUnits;
+    }
+
+    enum State
+    {
+        needUnits,
+        gotUnits,
+        done
+    }
+    State state;
+
+    void tryEnsureUnits()
+    {
+        while (true)
+        {
+            final switch (state)
+            {
+            case State.needUnits:
+                receive(
+                        (Tid origin, CurlMessage!(immutable(Unit)[]) _data)
+                        {
+                            if (origin != workerTid)
+                                return false;
+                            units = cast(Unit[]) _data.data;
+                            state = State.gotUnits;
+                            return true;
+                        },
+                        (Tid origin, CurlMessage!bool f)
+                        {
+                            if (origin != workerTid)
+                                return false;
+                            state = state.done;
+                            return true;
+                        }
+                        );
+                break;
+            case State.gotUnits: return;
+            case State.done:
+                return;
+            }
+        }
+    }
+}
+
+// Workaround bug #2458
+// It should really be defined inside the byLineAsync method.
+// Do not create instances of this struct since it will be
+// moved when the bug has been fixed.
+// Range that reads one line at a time asynchronously.
+static struct AsyncLineInputRange(Char)
+{
+    private Char[] line;
+    mixin WorkerThreadProtocol!(Char, line);
+
+    private Tid workerTid;
+    private State running;
+
+    private this(Tid tid, size_t transmitBuffers, size_t bufferSize)
+    {
+        workerTid = tid;
+        state = State.needUnits;
+
+        // Send buffers to other thread for it to use.  Since no mechanism is in
+        // place for moving ownership a cast to shared is done here and casted
+        // back to non-shared in the receiving end.
+        foreach (i ; 0..transmitBuffers)
+        {
+            auto arr = new Char[](bufferSize);
+            workerTid.send(cast(immutable(Char[]))arr);
+        }
+    }
+}
+
+
+/** HTTP/FTP fetch content as a range of lines asynchronously.
+ *
+ * A range of lines is returned immediately and the request that fetches the
+ * lines is performed in another thread. If the method or other request
+ * properties is to be customized then set the $(D conn) parameter with a
+ * HTTP/FTP instance that has these properties set.
+ *
+ * If $(D postData) is non-_null the method will be set to $(D post) for HTTP
+ * requests.
+ *
+ * The background thread will buffer up to transmitBuffers number of lines
+ * before it stops receiving data from network. When the main thread reads the
+ * lines from the range it frees up buffers and allows for the background thread
+ * to receive more data from the network.
+ *
+ * If no data is available and the main thread accesses the range it will block
+ * until data becomes available. An exception to this is the $(D wait(Duration)) method on
+ * the $(LREF AsyncLineInputRange). This method will wait at maximum for the
+ * specified duration and return true if data is available.
+ *
+ * Example:
+ * ----
+ * import std.net.curl, std.stdio;
+ * // Get some pages in the background
+ * auto range1 = byLineAsync("www.google.com");
+ * auto range2 = byLineAsync("www.wikipedia.org");
+ * foreach (line; byLineAsync("dlang.org"))
+ *     writeln(line);
+ *
+ * // Lines already fetched in the background and ready
+ * foreach (line; range1) writeln(line);
+ * foreach (line; range2) writeln(line);
+ * ----
+ *
+ * ----
+ * import std.net.curl, std.stdio;
+ * // Get a line in a background thread and wait in
+ * // main thread for 2 seconds for it to arrive.
+ * auto range3 = byLineAsync("dlang.com");
+ * if (range.wait(dur!"seconds"(2)))
+ *     writeln(range.front);
+ * else
+ *     writeln("No line received after 2 seconds!");
+ * ----
+ *
+ * Params:
+ * url = The url to receive content from
+ * postData = Data to HTTP Post
+ * keepTerminator = KeepTerminator.yes signals that the line terminator should be
+ *                  returned as part of the lines in the range.
+ * terminator = The character that terminates a line
+ * transmitBuffers = The number of lines buffered asynchronously
+ * conn = The connection to use e.g. HTTP or FTP.
+ *
+ * Returns:
+ * A range of Char[] with the content of the resource pointer to by the
+ * URL.
+ */
+auto byLineAsync(Conn = AutoProtocol, Terminator = char, Char = char, PostUnit)
+            (const(char)[] url, const(PostUnit)[] postData,
+             KeepTerminator keepTerminator = KeepTerminator.no,
+             Terminator terminator = '\n',
+             size_t transmitBuffers = 10, Conn conn = Conn())
+    if (isCurlConn!Conn && isSomeChar!Char && isSomeChar!Terminator)
+{
+    static if (is(Conn : AutoProtocol))
+    {
+        if (isFTPUrl(url))
+            return byLineAsync(url, postData, keepTerminator,
+                               terminator, transmitBuffers, FTP());
+        else
+            return byLineAsync(url, postData, keepTerminator,
+                               terminator, transmitBuffers, HTTP());
+    }
+    else
+    {
+        // 50 is just an arbitrary number for now
+        setMaxMailboxSize(thisTid, 50, OnCrowding.block);
+        auto tid = spawn(&_spawnAsync!(Conn, Char, Terminator));
+        tid.send(thisTid);
+        tid.send(terminator);
+        tid.send(keepTerminator == KeepTerminator.yes);
+
+        _asyncDuplicateConnection(url, conn, postData, tid);
+
+        return AsyncLineInputRange!Char(tid, transmitBuffers,
+                                        Conn.defaultAsyncStringBufferSize);
+    }
+}
+
+/// ditto
+auto byLineAsync(Conn = AutoProtocol, Terminator = char, Char = char)
+            (const(char)[] url, KeepTerminator keepTerminator = KeepTerminator.no,
+             Terminator terminator = '\n',
+             size_t transmitBuffers = 10, Conn conn = Conn())
+{
+    static if (is(Conn : AutoProtocol))
+    {
+        if (isFTPUrl(url))
+            return byLineAsync(url, cast(void[])null, keepTerminator,
+                               terminator, transmitBuffers, FTP());
+        else
+            return byLineAsync(url, cast(void[])null, keepTerminator,
+                               terminator, transmitBuffers, HTTP());
+    }
+    else
+    {
+        return byLineAsync(url, cast(void[])null, keepTerminator,
+                           terminator, transmitBuffers, conn);
+    }
+}
+
+unittest
+{
+    foreach (host; [testServer.addr, "http://"~testServer.addr])
+    {
+        testServer.handle((s) {
+            auto req = s.recvReq;
+            s.send(httpOK("Line1\nLine2\nLine3"));
+        });
+        assert(byLineAsync(host).equal(["Line1", "Line2", "Line3"]));
+    }
+}
+
+
+// Workaround bug #2458
+// It should really be defined inside the byLineAsync method.
+// Do not create instances of this struct since it will be
+// moved when the bug has been fixed.
+// Range that reads one chunk at a time asynchronously.
+static struct AsyncChunkInputRange
+{
+    private ubyte[] chunk;
+    mixin WorkerThreadProtocol!(ubyte, chunk);
+
+    private Tid workerTid;
+    private State running;
+
+    private this(Tid tid, size_t transmitBuffers, size_t chunkSize)
+    {
+        workerTid = tid;
+        state = State.needUnits;
+
+        // Send buffers to other thread for it to use.  Since no mechanism is in
+        // place for moving ownership a cast to shared is done here and a cast
+        // back to non-shared in the receiving end.
+        foreach (i ; 0..transmitBuffers)
+        {
+            ubyte[] arr = new ubyte[](chunkSize);
+            workerTid.send(cast(immutable(ubyte[]))arr);
+        }
+    }
+}
+
+/** HTTP/FTP fetch content as a range of chunks asynchronously.
+ *
+ * A range of chunks is returned immediately and the request that fetches the
+ * chunks is performed in another thread. If the method or other request
+ * properties is to be customized then set the $(D conn) parameter with a
+ * HTTP/FTP instance that has these properties set.
+ *
+ * If $(D postData) is non-_null the method will be set to $(D post) for HTTP
+ * requests.
+ *
+ * The background thread will buffer up to transmitBuffers number of chunks
+ * before is stops receiving data from network. When the main thread reads the
+ * chunks from the range it frees up buffers and allows for the background
+ * thread to receive more data from the network.
+ *
+ * If no data is available and the main thread access the range it will block
+ * until data becomes available. An exception to this is the $(D wait(Duration))
+ * method on the $(LREF AsyncChunkInputRange). This method will wait at maximum for the specified
+ * duration and return true if data is available.
+ *
+ * Example:
+ * ----
+ * import std.net.curl, std.stdio;
+ * // Get some pages in the background
+ * auto range1 = byChunkAsync("www.google.com", 100);
+ * auto range2 = byChunkAsync("www.wikipedia.org");
+ * foreach (chunk; byChunkAsync("dlang.org"))
+ *     writeln(chunk); // chunk is ubyte[100]
+ *
+ * // Chunks already fetched in the background and ready
+ * foreach (chunk; range1) writeln(chunk);
+ * foreach (chunk; range2) writeln(chunk);
+ * ----
+ *
+ * ----
+ * import std.net.curl, std.stdio;
+ * // Get a line in a background thread and wait in
+ * // main thread for 2 seconds for it to arrive.
+ * auto range3 = byChunkAsync("dlang.com", 10);
+ * if (range.wait(dur!"seconds"(2)))
+ *     writeln(range.front);
+ * else
+ *     writeln("No chunk received after 2 seconds!");
+ * ----
+ *
+ * Params:
+ * url = The url to receive content from
+ * postData = Data to HTTP Post
+ * chunkSize = The size of the chunks
+ * transmitBuffers = The number of chunks buffered asynchronously
+ * conn = The connection to use e.g. HTTP or FTP.
+ *
+ * Returns:
+ * A range of ubyte[chunkSize] with the content of the resource pointer to by
+ * the URL.
+ */
+auto byChunkAsync(Conn = AutoProtocol, PostUnit)
+           (const(char)[] url, const(PostUnit)[] postData,
+            size_t chunkSize = 1024, size_t transmitBuffers = 10,
+            Conn conn = Conn())
+    if (isCurlConn!(Conn))
+{
+    static if (is(Conn : AutoProtocol))
+    {
+        if (isFTPUrl(url))
+            return byChunkAsync(url, postData, chunkSize,
+                                transmitBuffers, FTP());
+        else
+            return byChunkAsync(url, postData, chunkSize,
+                                transmitBuffers, HTTP());
+    }
+    else
+    {
+        // 50 is just an arbitrary number for now
+        setMaxMailboxSize(thisTid, 50, OnCrowding.block);
+        auto tid = spawn(&_spawnAsync!(Conn, ubyte));
+        tid.send(thisTid);
+
+        _asyncDuplicateConnection(url, conn, postData, tid);
+
+        return AsyncChunkInputRange(tid, transmitBuffers, chunkSize);
+    }
+}
+
+/// ditto
+auto byChunkAsync(Conn = AutoProtocol)
+           (const(char)[] url,
+            size_t chunkSize = 1024, size_t transmitBuffers = 10,
+            Conn conn = Conn())
+    if (isCurlConn!(Conn))
+{
+    static if (is(Conn : AutoProtocol))
+    {
+        if (isFTPUrl(url))
+            return byChunkAsync(url, cast(void[])null, chunkSize,
+                                transmitBuffers, FTP());
+        else
+            return byChunkAsync(url, cast(void[])null, chunkSize,
+                                transmitBuffers, HTTP());
+    }
+    else
+    {
+        return byChunkAsync(url, cast(void[])null, chunkSize,
+                            transmitBuffers, conn);
+    }
+}
+
+unittest
+{
+    foreach (host; [testServer.addr, "http://"~testServer.addr])
+    {
+        testServer.handle((s) {
+            auto req = s.recvReq;
+            s.send(httpOK(cast(ubyte[])[0, 1, 2, 3, 4, 5]));
+        });
+        assert(byChunkAsync(host, 2).equal([[0, 1], [2, 3], [4, 5]]));
+    }
+}
+
+
+/* Used by byLineAsync/byChunkAsync to duplicate an existing connection
+ * that can be used exclusively in a spawned thread.
+ */
+private void _asyncDuplicateConnection(Conn, PostData)
+    (const(char)[] url, Conn conn, PostData postData, Tid tid)
+{
+    // no move semantic available in std.concurrency ie. must use casting.
+    auto connDup = conn.dup();
+    connDup.url = url;
+
+    static if ( is(Conn : HTTP) )
+    {
+        connDup.p.headersOut = null;
+        connDup.method = conn.method == HTTP.Method.undefined ?
+            HTTP.Method.get : conn.method;
+        if (postData !is null)
+        {
+            if (connDup.method == HTTP.Method.put)
+            {
+                connDup.handle.set(CurlOption.infilesize_large,
+                                   postData.length);
+            }
+            else
+            {
+                // post
+                connDup.method = HTTP.Method.post;
+                connDup.handle.set(CurlOption.postfieldsize_large,
+                                   postData.length);
+            }
+            connDup.handle.set(CurlOption.copypostfields,
+                               cast(void*) postData.ptr);
+        }
+        tid.send(cast(ulong)connDup.handle.handle);
+        tid.send(connDup.method);
+    }
+    else
+    {
+        enforce!CurlException(postData is null,
+                                "Cannot put ftp data using byLineAsync()");
+        tid.send(cast(ulong)connDup.handle.handle);
+        tid.send(HTTP.Method.undefined);
+    }
+    connDup.p.curl.handle = null; // make sure handle is not freed
+}
+
+/*
+  Mixin template for all supported curl protocols. This is the commom
+  functionallity such as timeouts and network interface settings. This should
+  really be in the HTTP/FTP/SMTP structs but the documentation tool does not
+  support a mixin to put its doc strings where a mixin is done. Therefore docs
+  in this template is copied into each of HTTP/FTP/SMTP below.
+*/
+private mixin template Protocol()
+{
+
+    /// Value to return from $(D onSend)/$(D onReceive) delegates in order to
+    /// pause a request
+    alias requestPause = CurlReadFunc.pause;
+
+    /// Value to return from onSend delegate in order to abort a request
+    alias requestAbort = CurlReadFunc.abort;
+
+    static uint defaultAsyncStringBufferSize = 100;
+
+    /**
+       The curl handle used by this connection.
+    */
+    @property ref Curl handle() return
+    {
+        return p.curl;
+    }
+
+    /**
+       True if the instance is stopped. A stopped instance is not usable.
+    */
+    @property bool isStopped()
+    {
+        return p.curl.stopped;
+    }
+
+    /// Stop and invalidate this instance.
+    void shutdown()
+    {
+        p.curl.shutdown();
+    }
+
+    /** Set verbose.
+        This will print request information to stderr.
+     */
+    @property void verbose(bool on)
+    {
+        p.curl.set(CurlOption.verbose, on ? 1L : 0L);
+    }
+
+    // Connection settings
+
+    /// Set timeout for activity on connection.
+    @property void dataTimeout(Duration d)
+    {
+        p.curl.set(CurlOption.low_speed_limit, 1);
+        p.curl.set(CurlOption.low_speed_time, d.total!"seconds");
+    }
+
+    /** Set maximum time an operation is allowed to take.
+        This includes dns resolution, connecting, data transfer, etc.
+     */
+    @property void operationTimeout(Duration d)
+    {
+        p.curl.set(CurlOption.timeout_ms, d.total!"msecs");
+    }
+
+    /// Set timeout for connecting.
+    @property void connectTimeout(Duration d)
+    {
+        p.curl.set(CurlOption.connecttimeout_ms, d.total!"msecs");
+    }
+
+    // Network settings
+
+    /** Proxy
+     *  See: $(WEB curl.haxx.se/libcurl/c/curl_easy_setopt.html#CURLOPTPROXY, _proxy)
+     */
+    @property void proxy(const(char)[] host)
+    {
+        p.curl.set(CurlOption.proxy, host);
+    }
+
+    /** Proxy port
+     *  See: $(WEB curl.haxx.se/libcurl/c/curl_easy_setopt.html#CURLOPTPROXYPORT, _proxy_port)
+     */
+    @property void proxyPort(ushort port)
+    {
+        p.curl.set(CurlOption.proxyport, cast(long) port);
+    }
+
+    /// Type of proxy
+    alias CurlProxy = etc.c.curl.CurlProxy;
+
+    /** Proxy type
+     *  See: $(WEB curl.haxx.se/libcurl/c/curl_easy_setopt.html#CURLOPTPROXY, _proxy_type)
+     */
+    @property void proxyType(CurlProxy type)
+    {
+        p.curl.set(CurlOption.proxytype, cast(long) type);
+    }
+
+    /// DNS lookup timeout.
+    @property void dnsTimeout(Duration d)
+    {
+        p.curl.set(CurlOption.dns_cache_timeout, d.total!"msecs");
+    }
+
+    /**
+     * The network interface to use in form of the the IP of the interface.
+     *
+     * Example:
+     * ----
+     * theprotocol.netInterface = "192.168.1.32";
+     * theprotocol.netInterface = [ 192, 168, 1, 32 ];
+     * ----
+     *
+     * See: $(XREF socket, InternetAddress)
+     */
+    @property void netInterface(const(char)[] i)
+    {
+        p.curl.set(CurlOption.intrface, i);
+    }
+
+    /// ditto
+    @property void netInterface(const(ubyte)[4] i)
+    {
+        auto str = format("%d.%d.%d.%d", i[0], i[1], i[2], i[3]);
+        netInterface = str;
+    }
+
+    /// ditto
+    @property void netInterface(InternetAddress i)
+    {
+        netInterface = i.toAddrString();
+    }
+
+    /**
+       Set the local outgoing port to use.
+       Params:
+       port = the first outgoing port number to try and use
+    */
+    @property void localPort(ushort port)
+    {
+        p.curl.set(CurlOption.localport, cast(long)port);
+    }
+
+    /**
+       Set the local outgoing port range to use.
+       This can be used together with the localPort property.
+       Params:
+       range = if the first port is occupied then try this many
+               port number forwards
+    */
+    @property void localPortRange(ushort range)
+    {
+        p.curl.set(CurlOption.localportrange, cast(long)range);
+    }
+
+    /** Set the tcp no-delay socket option on or off.
+        See: $(WEB curl.haxx.se/libcurl/c/curl_easy_setopt.html#CURLOPTTCPNODELAY, nodelay)
+    */
+    @property void tcpNoDelay(bool on)
+    {
+        p.curl.set(CurlOption.tcp_nodelay, cast(long) (on ? 1 : 0) );
+    }
+
+    /** Sets whether SSL peer certificates should be verified.
+        See: $(WEB curl.haxx.se/libcurl/c/curl_easy_setopt.html#CURLOPTSSLVERIFYPEER, verifypeer)
+    */
+    @property void verifyPeer(bool on)
+    {
+      p.curl.set(CurlOption.ssl_verifypeer, on ? 1 : 0);
+    }
+
+    /** Sets whether the host within an SSL certificate should be verified.
+        See: $(WEB curl.haxx.se/libcurl/c/curl_easy_setopt.html#CURLOPTSSLVERIFYHOST, verifypeer)
+    */
+    @property void verifyHost(bool on)
+    {
+      p.curl.set(CurlOption.ssl_verifyhost, on ? 2 : 0);
+    }
+
+    // Authentication settings
+
+    /**
+       Set the user name, password and optionally domain for authentication
+       purposes.
+
+       Some protocols may need authentication in some cases. Use this
+       function to provide credentials.
+
+       Params:
+       username = the username
+       password = the password
+       domain = used for NTLM authentication only and is set to the NTLM domain
+                name
+    */
+    void setAuthentication(const(char)[] username, const(char)[] password,
+                           const(char)[] domain = "")
+    {
+        if (!domain.empty)
+            username = format("%s/%s", domain, username);
+        p.curl.set(CurlOption.userpwd, format("%s:%s", username, password));
+    }
+
+    unittest
+    {
+        testServer.handle((s) {
+            auto req = s.recvReq;
+            assert(req.hdrs.canFind("GET /"));
+            assert(req.hdrs.canFind("Basic dXNlcjpwYXNz"));
+            s.send(httpOK());
+        });
+
+        auto http = HTTP(testServer.addr);
+        http.onReceive = (ubyte[] data) { return data.length; };
+        http.setAuthentication("user", "pass");
+        http.perform();
+    }
+
+    /**
+       Set the user name and password for proxy authentication.
+
+       Params:
+       username = the username
+       password = the password
+    */
+    void setProxyAuthentication(const(char)[] username, const(char)[] password)
+    {
+        p.curl.set(CurlOption.proxyuserpwd,
+            format("%s:%s",
+                username.replace(":", "%3A"),
+                password.replace(":", "%3A"))
+        );
+    }
+
+    /**
+     * The event handler that gets called when data is needed for sending. The
+     * length of the $(D void[]) specifies the maximum number of bytes that can
+     * be sent.
+     *
+     * Returns:
+     * The callback returns the number of elements in the buffer that have been
+     * filled and are ready to send.
+     * The special value $(D .abortRequest) can be returned in order to abort the
+     * current request.
+     * The special value $(D .pauseRequest) can be returned in order to pause the
+     * current request.
+     *
+     * Example:
+     * ----
+     * import std.net.curl;
+     * string msg = "Hello world";
+     * auto client = HTTP("dlang.org");
+     * client.onSend = delegate size_t(void[] data)
+     * {
+     *     auto m = cast(void[])msg;
+     *     size_t length = m.length > data.length ? data.length : m.length;
+     *     if (length == 0) return 0;
+     *     data[0..length] = m[0..length];
+     *     msg = msg[length..$];
+     *     return length;
+     * };
+     * client.perform();
+     * ----
+     */
+    @property void onSend(size_t delegate(void[]) callback)
+    {
+        p.curl.clear(CurlOption.postfields); // cannot specify data when using callback
+        p.curl.onSend = callback;
+    }
+
+    /**
+      * The event handler that receives incoming data. Be sure to copy the
+      * incoming ubyte[] since it is not guaranteed to be valid after the
+      * callback returns.
+      *
+      * Returns:
+      * The callback returns the number of incoming bytes read. If the entire array is
+      * not read the request will abort.
+      * The special value .pauseRequest can be returned in order to pause the
+      * current request.
+      *
+      * Example:
+      * ----
+      * import std.net.curl, std.stdio;
+      * auto client = HTTP("dlang.org");
+      * client.onReceive = (ubyte[] data)
+      * {
+      *     writeln("Got data", to!(const(char)[])(data));
+      *     return data.length;
+      * };
+      * client.perform();
+      * ----
+      */
+    @property void onReceive(size_t delegate(ubyte[]) callback)
+    {
+        p.curl.onReceive = callback;
+    }
+
+    /**
+      * The event handler that gets called to inform of upload/download progress.
+      *
+      * Params:
+      * dlTotal = total bytes to download
+      * dlNow = currently downloaded bytes
+      * ulTotal = total bytes to upload
+      * ulNow = currently uploaded bytes
+      *
+      * Returns:
+      * Return 0 from the callback to signal success, return non-zero to abort
+      *          transfer
+      *
+      * Example:
+      * ----
+      * import std.net.curl, std.stdio;
+      * auto client = HTTP("dlang.org");
+      * client.onProgress = delegate int(size_t dl, size_t dln, size_t ul, size_t ult)
+      * {
+      *     writeln("Progress: downloaded ", dln, " of ", dl);
+      *     writeln("Progress: uploaded ", uln, " of ", ul);
+      * };
+      * client.perform();
+      * ----
+      */
+    @property void onProgress(int delegate(size_t dlTotal, size_t dlNow,
+                                           size_t ulTotal, size_t ulNow) callback)
+    {
+        p.curl.onProgress = callback;
+    }
+}
+
+/*
+  Decode $(D ubyte[]) array using the provided EncodingScheme up to maxChars
+  Returns: Tuple of ubytes read and the $(D Char[]) characters decoded.
+           Not all ubytes are guaranteed to be read in case of decoding error.
+*/
+private Tuple!(size_t,Char[])
+decodeString(Char = char)(const(ubyte)[] data,
+                          EncodingScheme scheme,
+                          size_t maxChars = size_t.max)
+{
+    Char[] res;
+    auto startLen = data.length;
+    size_t charsDecoded = 0;
+    while (data.length && charsDecoded < maxChars)
+    {
+        dchar dc = scheme.safeDecode(data);
+        if (dc == INVALID_SEQUENCE)
+        {
+            return typeof(return)(size_t.max, cast(Char[])null);
+        }
+        charsDecoded++;
+        res ~= dc;
+    }
+    return typeof(return)(startLen-data.length, res);
+}
+
+/*
+  Decode $(D ubyte[]) array using the provided $(D EncodingScheme) until a the
+  line terminator specified is found. The basesrc parameter is effectively
+  prepended to src as the first thing.
+
+  This function is used for decoding as much of the src buffer as
+  possible until either the terminator is found or decoding fails. If
+  it fails as the last data in the src it may mean that the src buffer
+  were missing some bytes in order to represent a correct code
+  point. Upon the next call to this function more bytes have been
+  received from net and the failing bytes should be given as the
+  basesrc parameter. It is done this way to minimize data copying.
+
+  Returns: true if a terminator was found
+           Not all ubytes are guaranteed to be read in case of decoding error.
+           any decoded chars will be inserted into dst.
+*/
+private bool decodeLineInto(Terminator, Char = char)(ref const(ubyte)[] basesrc,
+                                                     ref const(ubyte)[] src,
+                                                     ref Char[] dst,
+                                                     EncodingScheme scheme,
+                                                     Terminator terminator)
+{
+    auto startLen = src.length;
+    size_t charsDecoded = 0;
+    // if there is anything in the basesrc then try to decode that
+    // first.
+    if (basesrc.length != 0)
+    {
+        // Try to ensure 4 entries in the basesrc by copying from src.
+        auto blen = basesrc.length;
+        size_t len = (basesrc.length + src.length) >= 4 ?
+                     4 : basesrc.length + src.length;
+        basesrc.length = len;
+
+        dchar dc = scheme.safeDecode(basesrc);
+        if (dc == INVALID_SEQUENCE)
+        {
+            enforce!CurlException(len != 4, "Invalid code sequence");
+            return false;
+        }
+        dst ~= dc;
+        src = src[len-basesrc.length-blen .. $]; // remove used ubytes from src
+        basesrc.length = 0;
+    }
+
+    while (src.length)
+    {
+        auto lsrc = src;
+        dchar dc = scheme.safeDecode(src);
+        if (dc == INVALID_SEQUENCE)
+        {
+            if (src.empty)
+            {
+                // The invalid sequence was in the end of the src.  Maybe there
+                // just need to be more bytes available so these last bytes are
+                // put back to src for later use.
+                src = lsrc;
+                return false;
+            }
+            dc = '?';
+        }
+        dst ~= dc;
+
+        if (dst.endsWith(terminator))
+            return true;
+    }
+    return false; // no terminator found
+}
+
+/**
+  * HTTP client functionality.
+  *
+  * Example:
+  * ---
+  * import std.net.curl, std.stdio;
+  *
+  * // Get with custom data receivers
+  * auto http = HTTP("dlang.org");
+  * http.onReceiveHeader =
+  *     (in char[] key, in char[] value) { writeln(key ~ ": " ~ value); };
+  * http.onReceive = (ubyte[] data) { /+ drop +/ return data.length; };
+  * http.perform();
+  *
+  * // Put with data senders
+  * auto msg = "Hello world";
+  * http.contentLength = msg.length;
+  * http.onSend = (void[] data)
+  * {
+  *     auto m = cast(void[])msg;
+  *     size_t len = m.length > data.length ? data.length : m.length;
+  *     if (len == 0) return len;
+  *     data[0..len] = m[0..len];
+  *     msg = msg[len..$];
+  *     return len;
+  * };
+  * http.perform();
+  *
+  * // Track progress
+  * http.method = HTTP.Method.get;
+  * http.url = "http://upload.wikimedia.org/wikipedia/commons/"
+  *            "5/53/Wikipedia-logo-en-big.png";
+  * http.onReceive = (ubyte[] data) { return data.length; };
+  * http.onProgress = (size_t dltotal, size_t dlnow,
+  *                    size_t ultotal, size_t ulnow)
+  * {
+  *     writeln("Progress ", dltotal, ", ", dlnow, ", ", ultotal, ", ", ulnow);
+  *     return 0;
+  * };
+  * http.perform();
+  * ---
+  *
+  * See_Also: $(WEB www.ietf.org/rfc/rfc2616.txt, RFC2616)
+  *
+  */
+struct HTTP
+{
+    mixin Protocol;
+
+    /// Authentication method equal to $(ECXREF curl, CurlAuth)
+    alias AuthMethod = CurlAuth;
+
+    static private uint defaultMaxRedirects = 10;
+
+    private struct Impl
+    {
+        ~this()
+        {
+			// WORKAROUND: prevent segfault
+            /*if (headersOut !is null)
+                Curl.curl.slist_free_all(headersOut);
+            if (curl.handle !is null) // work around RefCounted/emplace bug
+                curl.shutdown();*/
+        }
+        Curl curl;
+        curl_slist* headersOut;
+        string[string] headersIn;
+        string charset;
+
+        /// The status line of the final sub-request in a request.
+        StatusLine status;
+        private void delegate(StatusLine) onReceiveStatusLine;
+
+        /// The HTTP method to use.
+        Method method = Method.undefined;
+
+        @property void onReceiveHeader(void delegate(in char[] key,
+                                                     in char[] value) callback)
+        {
+            // Wrap incoming callback in order to separate http status line from
+            // http headers.  On redirected requests there may be several such
+            // status lines. The last one is the one recorded.
+            auto dg = (in char[] header)
+            {
+                import std.utf : UTFException;
+                try
+                {
+                    if (header.empty)
+                    {
+                        // header delimiter
+                        return;
+                    }
+                    if (header.startsWith("HTTP/"))
+                    {
+                        string[string] empty;
+                        headersIn = empty; // clear
+
+                        auto m = match(header, regex(r"^HTTP/(\d+)\.(\d+) (\d+) (.*)$"));
+                        if (m.empty)
+                        {
+                            // Invalid status line
+                        }
+                        else
+                        {
+                            status.majorVersion = to!ushort(m.captures[1]);
+                            status.minorVersion = to!ushort(m.captures[2]);
+                            status.code = to!ushort(m.captures[3]);
+                            status.reason = m.captures[4].idup;
+                            if (onReceiveStatusLine != null)
+                                onReceiveStatusLine(status);
+                        }
+                        return;
+                    }
+
+                    // Normal http header
+                    auto m = match(cast(char[]) header, regex("(.*?): (.*)$"));
+
+                    auto fieldName = m.captures[1].toLower().idup;
+                    if (fieldName == "content-type")
+                    {
+                        auto mct = match(cast(char[]) m.captures[2],
+                                         regex("charset=([^;]*)"));
+                        if (!mct.empty && mct.captures.length > 1)
+                            charset = mct.captures[1].idup;
+                    }
+
+                    if (!m.empty && callback !is null)
+                        callback(fieldName, m.captures[2]);
+                    headersIn[fieldName] = m.captures[2].idup;
+                }
+                catch(UTFException e)
+                {
+                    //munch it - a header should be all ASCII, any "wrong UTF" is broken header
+                }
+            };
+
+            curl.onReceiveHeader = dg;
+        }
+    }
+
+    private RefCounted!Impl p;
+
+    /** Time condition enumeration as an alias of $(ECXREF curl, CurlTimeCond)
+
+        $(WEB www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.25, _RFC2616 Section 14.25)
+    */
+    alias TimeCond = CurlTimeCond;
+
+    /**
+       Constructor taking the url as parameter.
+    */
+    static HTTP opCall(const(char)[] url)
+    {
+        HTTP http;
+        http.initialize();
+        http.url = url;
+        return http;
+    }
+
+    static HTTP opCall()
+    {
+        HTTP http;
+        http.initialize();
+        return http;
+    }
+
+    HTTP dup()
+    {
+        HTTP copy;
+        copy.initialize();
+        copy.p.method = p.method;
+        curl_slist* cur = p.headersOut;
+        curl_slist* newlist = null;
+        while (cur)
+        {
+            newlist = Curl.curl.slist_append(newlist, cur.data);
+            cur = cur.next;
+        }
+        copy.p.headersOut = newlist;
+        copy.p.curl.set(CurlOption.httpheader, copy.p.headersOut);
+        copy.p.curl = p.curl.dup();
+        copy.dataTimeout = _defaultDataTimeout;
+        copy.onReceiveHeader = null;
+        return copy;
+    }
+
+    private void initialize()
+    {
+        p.curl.initialize();
+        maxRedirects = HTTP.defaultMaxRedirects;
+        p.charset = "ISO-8859-1"; // Default charset defined in HTTP RFC
+        p.method = Method.undefined;
+        setUserAgent(HTTP.defaultUserAgent);
+        dataTimeout = _defaultDataTimeout;
+        onReceiveHeader = null;
+        verifyPeer = true;
+        verifyHost = true;
+    }
+
+    /**
+       Perform a http request.
+
+       After the HTTP client has been setup and possibly assigned callbacks the
+       $(D perform()) method will start performing the request towards the
+       specified server.
+
+       Params:
+       throwOnError = whether to throw an exception or return a CurlCode on error
+    */
+    CurlCode perform(ThrowOnError throwOnError = ThrowOnError.yes)
+    {
+        p.status.reset();
+
+        CurlOption opt;
+        final switch (p.method)
+        {
+        case Method.head:
+            p.curl.set(CurlOption.nobody, 1L);
+            opt = CurlOption.nobody;
+            break;
+        case Method.undefined:
+        case Method.get:
+            p.curl.set(CurlOption.httpget, 1L);
+            opt = CurlOption.httpget;
+            break;
+        case Method.post:
+            p.curl.set(CurlOption.post, 1L);
+            opt = CurlOption.post;
+            break;
+        case Method.put:
+            p.curl.set(CurlOption.upload, 1L);
+            opt = CurlOption.upload;
+            break;
+        case Method.del:
+            p.curl.set(CurlOption.customrequest, "DELETE");
+            opt = CurlOption.customrequest;
+            break;
+        case Method.options:
+            p.curl.set(CurlOption.customrequest, "OPTIONS");
+            opt = CurlOption.customrequest;
+            break;
+        case Method.trace:
+            p.curl.set(CurlOption.customrequest, "TRACE");
+            opt = CurlOption.customrequest;
+            break;
+        case Method.connect:
+            p.curl.set(CurlOption.customrequest, "CONNECT");
+            opt = CurlOption.customrequest;
+            break;
+        case Method.patch:
+            p.curl.set(CurlOption.customrequest, "PATCH");
+			// FIX: missing method
+            p.curl.set(CurlOption.post, 1L);
+            opt = CurlOption.customrequest;
+            break;
+        }
+
+        scope (exit) p.curl.clear(opt);
+        return p.curl.perform(throwOnError);
+    }
+
+    /// The URL to specify the location of the resource.
+    @property void url(const(char)[] url)
+    {
+        if (!startsWith(url.toLower(), "http://", "https://"))
+            url = "http://" ~ url;
+        p.curl.set(CurlOption.url, url);
+    }
+
+    /// Set the CA certificate bundle file to use for SSL peer verification
+    @property void caInfo(const(char)[] caFile)
+    {
+        p.curl.set(CurlOption.cainfo, caFile);
+    }
+
+    // This is a workaround for mixed in content not having its
+    // docs mixed in.
+    version (StdDdoc)
+    {
+        /// Value to return from $(D onSend)/$(D onReceive) delegates in order to
+        /// pause a request
+        alias requestPause = CurlReadFunc.pause;
+
+        /// Value to return from onSend delegate in order to abort a request
+        alias requestAbort = CurlReadFunc.abort;
+
+        /**
+           True if the instance is stopped. A stopped instance is not usable.
+        */
+        @property bool isStopped();
+
+        /// Stop and invalidate this instance.
+        void shutdown();
+
+        /** Set verbose.
+            This will print request information to stderr.
+        */
+        @property void verbose(bool on);
+
+        // Connection settings
+
+        /// Set timeout for activity on connection.
+        @property void dataTimeout(Duration d);
+
+        /** Set maximum time an operation is allowed to take.
+            This includes dns resolution, connecting, data transfer, etc.
+          */
+        @property void operationTimeout(Duration d);
+
+        /// Set timeout for connecting.
+        @property void connectTimeout(Duration d);
+
+        // Network settings
+
+        /** Proxy
+         *  See: $(WEB curl.haxx.se/libcurl/c/curl_easy_setopt.html#CURLOPTPROXY, _proxy)
+         */
+        @property void proxy(const(char)[] host);
+
+        /** Proxy port
+         *  See: $(WEB curl.haxx.se/libcurl/c/curl_easy_setopt.html#CURLOPTPROXYPORT, _proxy_port)
+         */
+        @property void proxyPort(ushort port);
+
+        /// Type of proxy
+        alias CurlProxy = etc.c.curl.CurlProxy;
+
+        /** Proxy type
+         *  See: $(WEB curl.haxx.se/libcurl/c/curl_easy_setopt.html#CURLOPTPROXY, _proxy_type)
+         */
+        @property void proxyType(CurlProxy type);
+
+        /// DNS lookup timeout.
+        @property void dnsTimeout(Duration d);
+
+        /**
+         * The network interface to use in form of the the IP of the interface.
+         *
+         * Example:
+         * ----
+         * theprotocol.netInterface = "192.168.1.32";
+         * theprotocol.netInterface = [ 192, 168, 1, 32 ];
+         * ----
+         *
+         * See: $(XREF socket, InternetAddress)
+         */
+        @property void netInterface(const(char)[] i);
+
+        /// ditto
+        @property void netInterface(const(ubyte)[4] i);
+
+        /// ditto
+        @property void netInterface(InternetAddress i);
+
+        /**
+           Set the local outgoing port to use.
+           Params:
+           port = the first outgoing port number to try and use
+        */
+        @property void localPort(ushort port);
+
+        /**
+           Set the local outgoing port range to use.
+           This can be used together with the localPort property.
+           Params:
+           range = if the first port is occupied then try this many
+           port number forwards
+        */
+        @property void localPortRange(ushort range);
+
+        /** Set the tcp no-delay socket option on or off.
+            See: $(WEB curl.haxx.se/libcurl/c/curl_easy_setopt.html#CURLOPTTCPNODELAY, nodelay)
+        */
+        @property void tcpNoDelay(bool on);
+
+        // Authentication settings
+
+        /**
+           Set the user name, password and optionally domain for authentication
+           purposes.
+
+           Some protocols may need authentication in some cases. Use this
+           function to provide credentials.
+
+           Params:
+           username = the username
+           password = the password
+           domain = used for NTLM authentication only and is set to the NTLM domain
+           name
+        */
+        void setAuthentication(const(char)[] username, const(char)[] password,
+                               const(char)[] domain = "");
+
+        /**
+           Set the user name and password for proxy authentication.
+
+           Params:
+           username = the username
+           password = the password
+        */
+        void setProxyAuthentication(const(char)[] username, const(char)[] password);
+
+        /**
+         * The event handler that gets called when data is needed for sending. The
+         * length of the $(D void[]) specifies the maximum number of bytes that can
+         * be sent.
+         *
+         * Returns:
+         * The callback returns the number of elements in the buffer that have been
+         * filled and are ready to send.
+         * The special value $(D .abortRequest) can be returned in order to abort the
+         * current request.
+         * The special value $(D .pauseRequest) can be returned in order to pause the
+         * current request.
+         *
+         * Example:
+         * ----
+         * import std.net.curl;
+         * string msg = "Hello world";
+         * auto client = HTTP("dlang.org");
+         * client.onSend = delegate size_t(void[] data)
+         * {
+         *     auto m = cast(void[])msg;
+         *     size_t length = m.length > data.length ? data.length : m.length;
+         *     if (length == 0) return 0;
+         *     data[0..length] = m[0..length];
+         *     msg = msg[length..$];
+         *     return length;
+         * };
+         * client.perform();
+         * ----
+         */
+        @property void onSend(size_t delegate(void[]) callback);
+
+        /**
+         * The event handler that receives incoming data. Be sure to copy the
+         * incoming ubyte[] since it is not guaranteed to be valid after the
+         * callback returns.
+         *
+         * Returns:
+         * The callback returns the incoming bytes read. If not the entire array is
+         * the request will abort.
+         * The special value .pauseRequest can be returned in order to pause the
+         * current request.
+         *
+         * Example:
+         * ----
+         * import std.net.curl, std.stdio;
+         * auto client = HTTP("dlang.org");
+         * client.onReceive = (ubyte[] data)
+         * {
+         *     writeln("Got data", to!(const(char)[])(data));
+         *     return data.length;
+         * };
+         * client.perform();
+         * ----
+         */
+        @property void onReceive(size_t delegate(ubyte[]) callback);
+
+        /**
+         * Register an event handler that gets called to inform of
+         * upload/download progress.
+         *
+         * Callback_parameters:
+         * $(CALLBACK_PARAMS)
+         *
+         * Callback_returns: Return 0 to signal success, return non-zero to
+         * abort transfer.
+         *
+         * Example:
+         * ----
+         * import std.net.curl, std.stdio;
+         * auto client = HTTP("dlang.org");
+         * client.onProgress = delegate int(size_t dl, size_t dln, size_t ul, size_t ult)
+         * {
+         *     writeln("Progress: downloaded ", dln, " of ", dl);
+         *     writeln("Progress: uploaded ", uln, " of ", ul);
+         * };
+         * client.perform();
+         * ----
+         */
+        @property void onProgress(int delegate(size_t dlTotal, size_t dlNow,
+                                               size_t ulTotal, size_t ulNow) callback);
+    }
+
+    /** Clear all outgoing headers.
+    */
+    void clearRequestHeaders()
+    {
+        if (p.headersOut !is null)
+            Curl.curl.slist_free_all(p.headersOut);
+        p.headersOut = null;
+        p.curl.clear(CurlOption.httpheader);
+    }
+
+    /** Add a header e.g. "X-CustomField: Something is fishy".
+     *
+     * There is no remove header functionality. Do a $(LREF clearRequestHeaders)
+     * and set the needed headers instead.
+     *
+     * Example:
+     * ---
+     * import std.net.curl;
+     * auto client = HTTP();
+     * client.addRequestHeader("X-Custom-ABC", "This is the custom value");
+     * auto content = get("dlang.org", client);
+     * ---
+     */
+    void addRequestHeader(const(char)[] name, const(char)[] value)
+    {
+        if (icmp(name, "User-Agent") == 0)
+            return setUserAgent(value);
+        string nv = format("%s: %s", name, value);
+        p.headersOut = Curl.curl.slist_append(p.headersOut,
+                                              nv.tempCString().buffPtr);
+        p.curl.set(CurlOption.httpheader, p.headersOut);
+    }
+
+    /**
+     * The default "User-Agent" value send with a request.
+     * It has the form "Phobos-std.net.curl/$(I PHOBOS_VERSION) (libcurl/$(I CURL_VERSION))"
+     */
+    static string defaultUserAgent() @property
+    {
+        import std.compiler : version_major, version_minor;
+
+        // http://curl.haxx.se/docs/versions.html
+        enum fmt = "Phobos-std.net.curl/%d.%03d (libcurl/%d.%d.%d)";
+        enum maxLen = fmt.length - "%d%03d%d%d%d".length + 10 + 10 + 3 + 3 + 3;
+
+        static char[maxLen] buf = void;
+        static string userAgent;
+
+        if (!userAgent.length)
+        {
+            auto curlVer = Curl.curl.version_info(CURLVERSION_NOW).version_num;
+            userAgent = cast(immutable)sformat(
+                buf, fmt, version_major, version_minor,
+                curlVer >> 16 & 0xFF, curlVer >> 8 & 0xFF, curlVer & 0xFF);
+        }
+        return userAgent;
+    }
+
+    /** Set the value of the user agent request header field.
+     *
+     * By default a request has it's "User-Agent" field set to $(LREF
+     * defaultUserAgent) even if $(D setUserAgent) was never called.  Pass
+     * an empty string to suppress the "User-Agent" field altogether.
+     */
+    void setUserAgent(const(char)[] userAgent)
+    {
+        p.curl.set(CurlOption.useragent, userAgent);
+    }
+
+    /** The headers read from a successful response.
+     *
+     */
+    @property string[string] responseHeaders()
+    {
+        return p.headersIn;
+    }
+
+    /// HTTP method used.
+    @property void method(Method m)
+    {
+        p.method = m;
+    }
+
+    /// ditto
+    @property Method method()
+    {
+        return p.method;
+    }
+
+    /**
+       HTTP status line of last response. One call to perform may
+       result in several requests because of redirection.
+    */
+    @property StatusLine statusLine()
+    {
+        return p.status;
+    }
+
+    /// Set the active cookie string e.g. "name1=value1;name2=value2"
+    void setCookie(const(char)[] cookie)
+    {
+        p.curl.set(CurlOption.cookie, cookie);
+    }
+
+    /// Set a file path to where a cookie jar should be read/stored.
+    void setCookieJar(const(char)[] path)
+    {
+        p.curl.set(CurlOption.cookiefile, path);
+        if (path.length)
+            p.curl.set(CurlOption.cookiejar, path);
+    }
+
+    /// Flush cookie jar to disk.
+    void flushCookieJar()
+    {
+        p.curl.set(CurlOption.cookielist, "FLUSH");
+    }
+
+    /// Clear session cookies.
+    void clearSessionCookies()
+    {
+        p.curl.set(CurlOption.cookielist, "SESS");
+    }
+
+    /// Clear all cookies.
+    void clearAllCookies()
+    {
+        p.curl.set(CurlOption.cookielist, "ALL");
+    }
+
+    /**
+       Set time condition on the request.
+
+       Params:
+       cond =  $(D CurlTimeCond.{none,ifmodsince,ifunmodsince,lastmod})
+       timestamp = Timestamp for the condition
+
+       $(WEB www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.25, _RFC2616 Section 14.25)
+    */
+    void setTimeCondition(HTTP.TimeCond cond, SysTime timestamp)
+    {
+        p.curl.set(CurlOption.timecondition, cond);
+        p.curl.set(CurlOption.timevalue, timestamp.toUnixTime());
+    }
+
+    /** Specifying data to post when not using the onSend callback.
+      *
+      * The data is NOT copied by the library.  Content-Type will default to
+      * application/octet-stream.  Data is not converted or encoded by this
+      * method.
+      *
+      * Example:
+      * ----
+      * import std.net.curl, std.stdio;
+      * auto http = HTTP("http://www.mydomain.com");
+      * http.onReceive = (ubyte[] data) { writeln(to!(const(char)[])(data)); return data.length; };
+      * http.postData = [1,2,3,4,5];
+      * http.perform();
+      * ----
+      */
+    @property void postData(const(void)[] data)
+    {
+        setPostData(data, "application/octet-stream");
+    }
+
+    /** Specifying data to post when not using the onSend callback.
+      *
+      * The data is NOT copied by the library.  Content-Type will default to
+      * text/plain.  Data is not converted or encoded by this method.
+      *
+      * Example:
+      * ----
+      * import std.net.curl, std.stdio;
+      * auto http = HTTP("http://www.mydomain.com");
+      * http.onReceive = (ubyte[] data) { writeln(to!(const(char)[])(data)); return data.length; };
+      * http.postData = "The quick....";
+      * http.perform();
+      * ----
+      */
+    @property void postData(const(char)[] data)
+    {
+        setPostData(data, "text/plain");
+    }
+
+    /**
+     * Specify data to post when not using the onSend callback, with
+     * user-specified Content-Type.
+     * Params:
+     *  data = Data to post.
+     *  contentType = MIME type of the data, for example, "text/plain" or
+     *      "application/octet-stream". See also:
+     *      $(LINK2 http://en.wikipedia.org/wiki/Internet_media_type,
+     *      Internet media type) on Wikipedia.
+     * -----
+     * import std.net.curl;
+     * auto http = HTTP("http://onlineform.example.com");
+     * auto data = "app=login&username=bob&password=s00perS3kret";
+     * http.setPostData(data, "application/x-www-form-urlencoded");
+     * http.onReceive = (ubyte[] data) { return data.length; };
+     * http.perform();
+     * -----
+     */
+    void setPostData(const(void)[] data, string contentType)
+    {
+        // cannot use callback when specifying data directly so it is disabled here.
+        p.curl.clear(CurlOption.readfunction);
+        addRequestHeader("Content-Type", contentType);
+        p.curl.set(CurlOption.postfields, cast(void*)data.ptr);
+        p.curl.set(CurlOption.postfieldsize, data.length);
+        if (method == Method.undefined)
+            method = Method.post;
+    }
+
+    unittest
+    {
+        testServer.handle((s) {
+            auto req = s.recvReq!ubyte;
+            assert(req.hdrs.canFind("POST /path"));
+            assert(req.bdy.canFind(cast(ubyte[])[0, 1, 2, 3, 4]));
+            assert(req.bdy.canFind(cast(ubyte[])[253, 254, 255]));
+            s.send(httpOK(cast(ubyte[])[17, 27, 35, 41]));
+        });
+        auto data = new ubyte[](256);
+        foreach (i, ref ub; data)
+            ub = cast(ubyte)i;
+
+        auto http = HTTP(testServer.addr~"/path");
+        http.postData = data;
+        ubyte[] res;
+        http.onReceive = (data) { res ~= data; return data.length; };
+        http.perform();
+        assert(res == cast(ubyte[])[17, 27, 35, 41]);
+    }
+
+    /**
+      * Set the event handler that receives incoming headers.
+      *
+      * The callback will receive a header field key, value as parameter. The
+      * $(D const(char)[]) arrays are not valid after the delegate has returned.
+      *
+      * Example:
+      * ----
+      * import std.net.curl, std.stdio;
+      * auto http = HTTP("dlang.org");
+      * http.onReceive = (ubyte[] data) { writeln(to!(const(char)[])(data)); return data.length; };
+      * http.onReceiveHeader = (in char[] key, in char[] value) { writeln(key, " = ", value); };
+      * http.perform();
+      * ----
+      */
+    @property void onReceiveHeader(void delegate(in char[] key,
+                                                 in char[] value) callback)
+    {
+        p.onReceiveHeader = callback;
+    }
+
+    /**
+       Callback for each received StatusLine.
+
+       Notice that several callbacks can be done for each call to
+       $(D perform()) due to redirections.
+
+       See_Also: $(LREF StatusLine)
+     */
+    @property void onReceiveStatusLine(void delegate(StatusLine) callback)
+    {
+        p.onReceiveStatusLine = callback;
+    }
+
+    /**
+       The content length in bytes when using request that has content
+       e.g. POST/PUT and not using chunked transfer. Is set as the
+       "Content-Length" header.  Set to ulong.max to reset to chunked transfer.
+    */
+    @property void contentLength(ulong len)
+    {
+        CurlOption lenOpt;
+
+        // Force post if necessary
+        if (p.method != Method.put && p.method != Method.post &&
+            p.method != Method.patch)
+            p.method = Method.post;
+
+        if (p.method == Method.post || p.method == Method.patch)
+            lenOpt = CurlOption.postfieldsize_large;
+        else
+            lenOpt = CurlOption.infilesize_large;
+
+        if (size_t.max != ulong.max && len == size_t.max)
+            len = ulong.max; // check size_t.max for backwards compat, turn into error
+
+        if (len == ulong.max)
+        {
+            // HTTP 1.1 supports requests with no length header set.
+            addRequestHeader("Transfer-Encoding", "chunked");
+            addRequestHeader("Expect", "100-continue");
+        }
+        else
+        {
+            p.curl.set(lenOpt, to!curl_off_t(len));
+        }
+    }
+
+    /**
+       Authentication method as specified in $(LREF AuthMethod).
+    */
+    @property void authenticationMethod(AuthMethod authMethod)
+    {
+        p.curl.set(CurlOption.httpauth, cast(long) authMethod);
+    }
+
+    /**
+       Set max allowed redirections using the location header.
+       uint.max for infinite.
+    */
+    @property void maxRedirects(uint maxRedirs)
+    {
+        if (maxRedirs == uint.max)
+        {
+            // Disable
+            p.curl.set(CurlOption.followlocation, 0);
+        }
+        else
+        {
+            p.curl.set(CurlOption.followlocation, 1);
+            p.curl.set(CurlOption.maxredirs, maxRedirs);
+        }
+    }
+
+    /** <a name="HTTP.Method"/ >The standard HTTP methods :
+     *  $(WEB www.w3.org/Protocols/rfc2616/rfc2616-sec5.html#sec5.1.1, _RFC2616 Section 5.1.1)
+     */
+    enum Method
+    {
+        undefined,
+        head, ///
+        get,  ///
+        post, ///
+        put,  ///
+        del,  ///
+        options, ///
+        trace,   ///
+        connect,  ///
+        patch, ///
+    }
+
+    /**
+       HTTP status line ie. the first line returned in an HTTP response.
+
+       If authentication or redirections are done then the status will be for
+       the last response received.
+    */
+    struct StatusLine
+    {
+        ushort majorVersion; /// Major HTTP version ie. 1 in HTTP/1.0.
+        ushort minorVersion; /// Minor HTTP version ie. 0 in HTTP/1.0.
+        ushort code;         /// HTTP status line code e.g. 200.
+        string reason;       /// HTTP status line reason string.
+
+        /// Reset this status line
+        @safe void reset()
+        {
+            majorVersion = 0;
+            minorVersion = 0;
+            code = 0;
+            reason = "";
+        }
+
+        ///
+        string toString()
+        {
+            return format("%s %s (%s.%s)",
+                          code, reason, majorVersion, minorVersion);
+        }
+    }
+
+} // HTTP
+
+/**
+   FTP client functionality.
+
+   See_Also: $(WEB tools.ietf.org/html/rfc959, RFC959)
+*/
+struct FTP
+{
+
+    mixin Protocol;
+
+    private struct Impl
+    {
+        ~this()
+        {
+            if (commands !is null)
+                Curl.curl.slist_free_all(commands);
+            if (curl.handle !is null) // work around RefCounted/emplace bug
+                curl.shutdown();
+        }
+        curl_slist* commands;
+        Curl curl;
+        string encoding;
+    }
+
+    private RefCounted!Impl p;
+
+    /**
+       FTP access to the specified url.
+    */
+    static FTP opCall(const(char)[] url)
+    {
+        FTP ftp;
+        ftp.initialize();
+        ftp.url = url;
+        return ftp;
+    }
+
+    static FTP opCall()
+    {
+        FTP ftp;
+        ftp.initialize();
+        return ftp;
+    }
+
+    FTP dup()
+    {
+        FTP copy = FTP();
+        copy.initialize();
+        copy.p.encoding = p.encoding;
+        copy.p.curl = p.curl.dup();
+        curl_slist* cur = p.commands;
+        curl_slist* newlist = null;
+        while (cur)
+        {
+            newlist = Curl.curl.slist_append(newlist, cur.data);
+            cur = cur.next;
+        }
+        copy.p.commands = newlist;
+        copy.p.curl.set(CurlOption.postquote, copy.p.commands);
+        copy.dataTimeout = _defaultDataTimeout;
+        return copy;
+    }
+
+    private void initialize()
+    {
+        p.curl.initialize();
+        p.encoding = "ISO-8859-1";
+        dataTimeout = _defaultDataTimeout;
+    }
+
+    /**
+       Performs the ftp request as it has been configured.
+
+       After a FTP client has been setup and possibly assigned callbacks the $(D
+       perform()) method will start performing the actual communication with the
+       server.
+
+       Params:
+       throwOnError = whether to throw an exception or return a CurlCode on error
+    */
+    CurlCode perform(ThrowOnError throwOnError = ThrowOnError.yes)
+    {
+        return p.curl.perform(throwOnError);
+    }
+
+    /// The URL to specify the location of the resource.
+    @property void url(const(char)[] url)
+    {
+        if (!startsWith(url.toLower(), "ftp://", "ftps://"))
+            url = "ftp://" ~ url;
+        p.curl.set(CurlOption.url, url);
+    }
+
+    // This is a workaround for mixed in content not having its
+    // docs mixed in.
+    version (StdDdoc)
+    {
+        /// Value to return from $(D onSend)/$(D onReceive) delegates in order to
+        /// pause a request
+        alias requestPause = CurlReadFunc.pause;
+
+        /// Value to return from onSend delegate in order to abort a request
+        alias requestAbort = CurlReadFunc.abort;
+
+        /**
+           True if the instance is stopped. A stopped instance is not usable.
+        */
+        @property bool isStopped();
+
+        /// Stop and invalidate this instance.
+        void shutdown();
+
+        /** Set verbose.
+            This will print request information to stderr.
+        */
+        @property void verbose(bool on);
+
+        // Connection settings
+
+        /// Set timeout for activity on connection.
+        @property void dataTimeout(Duration d);
+
+        /** Set maximum time an operation is allowed to take.
+            This includes dns resolution, connecting, data transfer, etc.
+          */
+        @property void operationTimeout(Duration d);
+
+        /// Set timeout for connecting.
+        @property void connectTimeout(Duration d);
+
+        // Network settings
+
+        /** Proxy
+         *  See: $(WEB curl.haxx.se/libcurl/c/curl_easy_setopt.html#CURLOPTPROXY, _proxy)
+         */
+        @property void proxy(const(char)[] host);
+
+        /** Proxy port
+         *  See: $(WEB curl.haxx.se/libcurl/c/curl_easy_setopt.html#CURLOPTPROXYPORT, _proxy_port)
+         */
+        @property void proxyPort(ushort port);
+
+        /// Type of proxy
+        alias CurlProxy = etc.c.curl.CurlProxy;
+
+        /** Proxy type
+         *  See: $(WEB curl.haxx.se/libcurl/c/curl_easy_setopt.html#CURLOPTPROXY, _proxy_type)
+         */
+        @property void proxyType(CurlProxy type);
+
+        /// DNS lookup timeout.
+        @property void dnsTimeout(Duration d);
+
+        /**
+         * The network interface to use in form of the the IP of the interface.
+         *
+         * Example:
+         * ----
+         * theprotocol.netInterface = "192.168.1.32";
+         * theprotocol.netInterface = [ 192, 168, 1, 32 ];
+         * ----
+         *
+         * See: $(XREF socket, InternetAddress)
+         */
+        @property void netInterface(const(char)[] i);
+
+        /// ditto
+        @property void netInterface(const(ubyte)[4] i);
+
+        /// ditto
+        @property void netInterface(InternetAddress i);
+
+        /**
+           Set the local outgoing port to use.
+           Params:
+           port = the first outgoing port number to try and use
+        */
+        @property void localPort(ushort port);
+
+        /**
+           Set the local outgoing port range to use.
+           This can be used together with the localPort property.
+           Params:
+           range = if the first port is occupied then try this many
+           port number forwards
+        */
+        @property void localPortRange(ushort range);
+
+        /** Set the tcp no-delay socket option on or off.
+            See: $(WEB curl.haxx.se/libcurl/c/curl_easy_setopt.html#CURLOPTTCPNODELAY, nodelay)
+        */
+        @property void tcpNoDelay(bool on);
+
+        // Authentication settings
+
+        /**
+           Set the user name, password and optionally domain for authentication
+           purposes.
+
+           Some protocols may need authentication in some cases. Use this
+           function to provide credentials.
+
+           Params:
+           username = the username
+           password = the password
+           domain = used for NTLM authentication only and is set to the NTLM domain
+           name
+        */
+        void setAuthentication(const(char)[] username, const(char)[] password,
+                               const(char)[] domain = "");
+
+        /**
+           Set the user name and password for proxy authentication.
+
+           Params:
+           username = the username
+           password = the password
+        */
+        void setProxyAuthentication(const(char)[] username, const(char)[] password);
+
+        /**
+         * The event handler that gets called when data is needed for sending. The
+         * length of the $(D void[]) specifies the maximum number of bytes that can
+         * be sent.
+         *
+         * Returns:
+         * The callback returns the number of elements in the buffer that have been
+         * filled and are ready to send.
+         * The special value $(D .abortRequest) can be returned in order to abort the
+         * current request.
+         * The special value $(D .pauseRequest) can be returned in order to pause the
+         * current request.
+         *
+         */
+        @property void onSend(size_t delegate(void[]) callback);
+
+        /**
+         * The event handler that receives incoming data. Be sure to copy the
+         * incoming ubyte[] since it is not guaranteed to be valid after the
+         * callback returns.
+         *
+         * Returns:
+         * The callback returns the incoming bytes read. If not the entire array is
+         * the request will abort.
+         * The special value .pauseRequest can be returned in order to pause the
+         * current request.
+         *
+         */
+        @property void onReceive(size_t delegate(ubyte[]) callback);
+
+        /**
+         * The event handler that gets called to inform of upload/download progress.
+         *
+         * Callback_parameters:
+         * $(CALLBACK_PARAMS)
+         *
+         * Callback_returns:
+         * Return 0 from the callback to signal success, return non-zero to
+         * abort transfer.
+         */
+        @property void onProgress(int delegate(size_t dlTotal, size_t dlNow,
+                                               size_t ulTotal, size_t ulNow) callback);
+    }
+
+    /** Clear all commands send to ftp server.
+    */
+    void clearCommands()
+    {
+        if (p.commands !is null)
+            Curl.curl.slist_free_all(p.commands);
+        p.commands = null;
+        p.curl.clear(CurlOption.postquote);
+    }
+
+    /** Add a command to send to ftp server.
+     *
+     * There is no remove command functionality. Do a $(LREF clearCommands) and
+     * set the needed commands instead.
+     *
+     * Example:
+     * ---
+     * import std.net.curl;
+     * auto client = FTP();
+     * client.addCommand("RNFR my_file.txt");
+     * client.addCommand("RNTO my_renamed_file.txt");
+     * upload("my_file.txt", "ftp.digitalmars.com", client);
+     * ---
+     */
+    void addCommand(const(char)[] command)
+    {
+        p.commands = Curl.curl.slist_append(p.commands,
+                                            command.tempCString().buffPtr);
+        p.curl.set(CurlOption.postquote, p.commands);
+    }
+
+    /// Connection encoding. Defaults to ISO-8859-1.
+    @property void encoding(string name)
+    {
+        p.encoding = name;
+    }
+
+    /// ditto
+    @property string encoding()
+    {
+        return p.encoding;
+    }
+
+    /**
+       The content length in bytes of the ftp data.
+    */
+    @property void contentLength(ulong len)
+    {
+        p.curl.set(CurlOption.infilesize_large, to!curl_off_t(len));
+    }
+}
+
+/**
+  * Basic SMTP protocol support.
+  *
+  * Example:
+  * ---
+  * import std.net.curl;
+  *
+  * // Send an email with SMTPS
+  * auto smtp = SMTP("smtps://smtp.gmail.com");
+  * smtp.setAuthentication("from.addr@gmail.com", "password");
+  * smtp.mailTo = ["<to.addr@gmail.com>"];
+  * smtp.mailFrom = "<from.addr@gmail.com>";
+  * smtp.message = "Example Message";
+  * smtp.perform();
+  * ---
+  *
+  * See_Also: $(WEB www.ietf.org/rfc/rfc2821.txt, RFC2821)
+  */
+struct SMTP
+{
+    mixin Protocol;
+
+    private struct Impl
+    {
+        ~this()
+        {
+            if (curl.handle !is null) // work around RefCounted/emplace bug
+                curl.shutdown();
+        }
+        Curl curl;
+
+        @property void message(string msg)
+        {
+            auto _message = msg;
+            /**
+                This delegate reads the message text and copies it.
+            */
+            curl.onSend = delegate size_t(void[] data)
+            {
+                if (!msg.length) return 0;
+                auto m = cast(void[])msg;
+                size_t to_copy = min(data.length, _message.length);
+                data[0..to_copy] = (cast(void[])_message)[0..to_copy];
+                _message = _message[to_copy..$];
+                return to_copy;
+            };
+        }
+    }
+
+    private RefCounted!Impl p;
+
+    /**
+        Sets to the URL of the SMTP server.
+    */
+    static SMTP opCall(const(char)[] url)
+    {
+        SMTP smtp;
+        smtp.initialize();
+        smtp.url = url;
+        return smtp;
+    }
+
+    static SMTP opCall()
+    {
+        SMTP smtp;
+        smtp.initialize();
+        return smtp;
+    }
+
+    /+ TODO: The other structs have this function.
+    SMTP dup()
+    {
+        SMTP copy = SMTP();
+        copy.initialize();
+        copy.p.encoding = p.encoding;
+        copy.p.curl = p.curl.dup();
+        curl_slist* cur = p.commands;
+        curl_slist* newlist = null;
+        while (cur)
+        {
+            newlist = Curl.curl.slist_append(newlist, cur.data);
+            cur = cur.next;
+        }
+        copy.p.commands = newlist;
+        copy.p.curl.set(CurlOption.postquote, copy.p.commands);
+        copy.dataTimeout = _defaultDataTimeout;
+        return copy;
+    }
+    +/
+
+    /**
+        Performs the request as configured.
+        Params:
+        throwOnError = whether to throw an exception or return a CurlCode on error
+    */
+    CurlCode perform(ThrowOnError throwOnError = ThrowOnError.yes)
+    {
+        return p.curl.perform(throwOnError);
+    }
+
+    /// The URL to specify the location of the resource.
+    @property void url(const(char)[] url)
+    {
+        auto lowered = url.toLower();
+
+        if (lowered.startsWith("smtps://"))
+        {
+            p.curl.set(CurlOption.use_ssl, CurlUseSSL.all);
+        }
+        else
+        {
+            enforce!CurlException(lowered.startsWith("smtp://"),
+                                    "The url must be for the smtp protocol.");
+        }
+        p.curl.set(CurlOption.url, url);
+    }
+
+    private void initialize()
+    {
+        p.curl.initialize();
+        p.curl.set(CurlOption.upload, 1L);
+        dataTimeout = _defaultDataTimeout;
+        verifyPeer = true;
+        verifyHost = true;
+    }
+
+    // This is a workaround for mixed in content not having its
+    // docs mixed in.
+    version (StdDdoc)
+    {
+        /// Value to return from $(D onSend)/$(D onReceive) delegates in order to
+        /// pause a request
+        alias requestPause = CurlReadFunc.pause;
+
+        /// Value to return from onSend delegate in order to abort a request
+        alias requestAbort = CurlReadFunc.abort;
+
+        /**
+           True if the instance is stopped. A stopped instance is not usable.
+        */
+        @property bool isStopped();
+
+        /// Stop and invalidate this instance.
+        void shutdown();
+
+        /** Set verbose.
+            This will print request information to stderr.
+        */
+        @property void verbose(bool on);
+
+        // Connection settings
+
+        /// Set timeout for activity on connection.
+        @property void dataTimeout(Duration d);
+
+        /** Set maximum time an operation is allowed to take.
+            This includes dns resolution, connecting, data transfer, etc.
+          */
+        @property void operationTimeout(Duration d);
+
+        /// Set timeout for connecting.
+        @property void connectTimeout(Duration d);
+
+        // Network settings
+
+        /** Proxy
+         *  See: $(WEB curl.haxx.se/libcurl/c/curl_easy_setopt.html#CURLOPTPROXY, _proxy)
+         */
+        @property void proxy(const(char)[] host);
+
+        /** Proxy port
+         *  See: $(WEB curl.haxx.se/libcurl/c/curl_easy_setopt.html#CURLOPTPROXYPORT, _proxy_port)
+         */
+        @property void proxyPort(ushort port);
+
+        /// Type of proxy
+        alias CurlProxy = etc.c.curl.CurlProxy;
+
+        /** Proxy type
+         *  See: $(WEB curl.haxx.se/libcurl/c/curl_easy_setopt.html#CURLOPTPROXY, _proxy_type)
+         */
+        @property void proxyType(CurlProxy type);
+
+        /// DNS lookup timeout.
+        @property void dnsTimeout(Duration d);
+
+        /**
+         * The network interface to use in form of the the IP of the interface.
+         *
+         * Example:
+         * ----
+         * theprotocol.netInterface = "192.168.1.32";
+         * theprotocol.netInterface = [ 192, 168, 1, 32 ];
+         * ----
+         *
+         * See: $(XREF socket, InternetAddress)
+         */
+        @property void netInterface(const(char)[] i);
+
+        /// ditto
+        @property void netInterface(const(ubyte)[4] i);
+
+        /// ditto
+        @property void netInterface(InternetAddress i);
+
+        /**
+           Set the local outgoing port to use.
+           Params:
+           port = the first outgoing port number to try and use
+        */
+        @property void localPort(ushort port);
+
+        /**
+           Set the local outgoing port range to use.
+           This can be used together with the localPort property.
+           Params:
+           range = if the first port is occupied then try this many
+           port number forwards
+        */
+        @property void localPortRange(ushort range);
+
+        /** Set the tcp no-delay socket option on or off.
+            See: $(WEB curl.haxx.se/libcurl/c/curl_easy_setopt.html#CURLOPTTCPNODELAY, nodelay)
+        */
+        @property void tcpNoDelay(bool on);
+
+        // Authentication settings
+
+        /**
+           Set the user name, password and optionally domain for authentication
+           purposes.
+
+           Some protocols may need authentication in some cases. Use this
+           function to provide credentials.
+
+           Params:
+           username = the username
+           password = the password
+           domain = used for NTLM authentication only and is set to the NTLM domain
+           name
+        */
+        void setAuthentication(const(char)[] username, const(char)[] password,
+                               const(char)[] domain = "");
+
+        /**
+           Set the user name and password for proxy authentication.
+
+           Params:
+           username = the username
+           password = the password
+        */
+        void setProxyAuthentication(const(char)[] username, const(char)[] password);
+
+        /**
+         * The event handler that gets called when data is needed for sending. The
+         * length of the $(D void[]) specifies the maximum number of bytes that can
+         * be sent.
+         *
+         * Returns:
+         * The callback returns the number of elements in the buffer that have been
+         * filled and are ready to send.
+         * The special value $(D .abortRequest) can be returned in order to abort the
+         * current request.
+         * The special value $(D .pauseRequest) can be returned in order to pause the
+         * current request.
+         */
+        @property void onSend(size_t delegate(void[]) callback);
+
+        /**
+         * The event handler that receives incoming data. Be sure to copy the
+         * incoming ubyte[] since it is not guaranteed to be valid after the
+         * callback returns.
+         *
+         * Returns:
+         * The callback returns the incoming bytes read. If not the entire array is
+         * the request will abort.
+         * The special value .pauseRequest can be returned in order to pause the
+         * current request.
+         */
+        @property void onReceive(size_t delegate(ubyte[]) callback);
+
+        /**
+         * The event handler that gets called to inform of upload/download progress.
+         *
+         * Callback_parameters:
+         * $(CALLBACK_PARAMS)
+         *
+         * Callback_returns:
+         * Return 0 from the callback to signal success, return non-zero to
+         * abort transfer.
+         */
+        @property void onProgress(int delegate(size_t dlTotal, size_t dlNow,
+                                               size_t ulTotal, size_t ulNow) callback);
+    }
+
+    /**
+        Setter for the sender's email address.
+    */
+    @property void mailFrom()(const(char)[] sender)
+    {
+        assert(!sender.empty, "Sender must not be empty");
+        p.curl.set(CurlOption.mail_from, sender);
+    }
+
+    /**
+        Setter for the recipient email addresses.
+    */
+    void mailTo()(const(char)[][] recipients...)
+    {
+        assert(!recipients.empty, "Recipient must not be empty");
+        curl_slist* recipients_list = null;
+        foreach(recipient; recipients)
+        {
+            recipients_list =
+                Curl.curl.slist_append(recipients_list,
+                                  recipient.tempCString().buffPtr);
+        }
+        p.curl.set(CurlOption.mail_rcpt, recipients_list);
+    }
+
+    /**
+        Sets the message body text.
+    */
+
+    @property void message(string msg)
+    {
+        p.message = msg;
+    }
+}
+
+/++
+    Exception thrown on errors in std.net.curl functions.
++/
+class CurlException : Exception
+{
+    /++
+        Params:
+            msg  = The message for the exception.
+            file = The file where the exception occurred.
+            line = The line number where the exception occurred.
+            next = The previous exception in the chain of exceptions, if any.
+      +/
+    @safe pure nothrow
+    this(string msg,
+         string file = __FILE__,
+         size_t line = __LINE__,
+         Throwable next = null)
+    {
+        super(msg, file, line, next);
+    }
+}
+
+/++
+    Exception thrown on timeout errors in std.net.curl functions.
++/
+class CurlTimeoutException : CurlException
+{
+    /++
+        Params:
+            msg  = The message for the exception.
+            file = The file where the exception occurred.
+            line = The line number where the exception occurred.
+            next = The previous exception in the chain of exceptions, if any.
+      +/
+    @safe pure nothrow
+    this(string msg,
+         string file = __FILE__,
+         size_t line = __LINE__,
+         Throwable next = null)
+    {
+        super(msg, file, line, next);
+    }
+}
+
+/// Equal to $(ECXREF curl, CURLcode)
+alias CurlCode = CURLcode;
+
+import std.typecons : Flag;
+/// Flag to specify whether or not an exception is thrown on error.
+alias ThrowOnError = Flag!"throwOnError";
+
+private struct CurlAPI
+{
+    static struct API
+    {
+    extern(C):
+        import core.stdc.config : c_long;
+        CURLcode function(c_long flags) global_init;
+        void function() global_cleanup;
+        curl_version_info_data * function(CURLversion) version_info;
+        CURL* function() easy_init;
+        CURLcode function(CURL *curl, CURLoption option,...) easy_setopt;
+        CURLcode function(CURL *curl) easy_perform;
+        CURL* function(CURL *curl) easy_duphandle;
+        char* function(CURLcode) easy_strerror;
+        CURLcode function(CURL *handle, int bitmask) easy_pause;
+        void function(CURL *curl) easy_cleanup;
+        curl_slist* function(curl_slist *, char *) slist_append;
+        void function(curl_slist *) slist_free_all;
+    }
+    __gshared API _api;
+    __gshared void* _handle;
+
+    static ref API instance() @property
+    {
+        import std.concurrency;
+        initOnce!_handle(loadAPI());
+        return _api;
+    }
+
+    static void* loadAPI()
+    {
+        version (Posix)
+        {
+            import core.sys.posix.dlfcn;
+            alias loadSym = dlsym;
+        }
+        else version (Windows)
+        {
+            import core.sys.windows.windows;
+            alias loadSym = GetProcAddress;
+        }
+        else
+            static assert(0, "unimplemented");
+
+        void* handle;
+        version (Posix)
+            handle = dlopen(null, RTLD_LAZY);
+        else version (Windows)
+            handle = GetModuleHandleA(null);
+        assert(handle !is null);
+
+        // try to load curl from the executable to allow static linking
+        if (loadSym(handle, "curl_global_init") is null)
+        {
+            version (Posix)
+                dlclose(handle);
+
+            version (OSX)
+                static immutable names = ["libcurl.4.dylib"];
+            else version (Posix)
+                static immutable names = ["libcurl.so", "libcurl.so.4", "libcurl-gnutls.so.4", "libcurl-nss.so.4", "libcurl.so.3"];
+            else version (Windows)
+                static immutable names = ["libcurl.dll", "curl.dll"];
+
+            foreach (name; names)
+            {
+                version (Posix)
+                    handle = dlopen(name.ptr, RTLD_LAZY);
+                else version (Windows)
+                    handle = LoadLibraryA(name.ptr);
+                if (handle !is null) break;
+            }
+
+            enforce!CurlException(handle !is null, "Failed to load curl, tried %(%s, %).".format(names));
+        }
+
+        foreach (mem; __traits(allMembers, API))
+        {
+            void* p = loadSym(handle, "curl_"~mem);
+
+            __traits(getMember, _api, mem) = cast(typeof(__traits(getMember, _api, mem)))
+                enforce!CurlException(p, "Couldn't load curl_"~mem~" from libcurl.");
+        }
+
+        enforce!CurlException(!_api.global_init(CurlGlobal.all),
+                              "Failed to initialize libcurl");
+
+        return handle;
+    }
+
+    shared static ~this()
+    {
+        if (_handle is null) return;
+
+        _api.global_cleanup();
+        version (Posix)
+        {
+            import core.sys.posix.dlfcn;
+            dlclose(_handle);
+        }
+        else version (Windows)
+        {
+            import core.sys.windows.windows;
+            FreeLibrary(_handle);
+        }
+        else
+            static assert(0, "unimplemented");
+
+        _api = API.init;
+        _handle = null;
+    }
+}
+
+/**
+  Wrapper to provide a better interface to libcurl than using the plain C API.
+  It is recommended to use the $(D HTTP)/$(D FTP) etc. structs instead unless
+  raw access to libcurl is needed.
+
+  Warning: This struct uses interior pointers for callbacks. Only allocate it
+  on the stack if you never move or copy it. This also means passing by reference
+  when passing Curl to other functions. Otherwise always allocate on
+  the heap.
+*/
+struct Curl
+{
+    alias OutData = void[];
+    alias InData = ubyte[];
+    bool stopped;
+
+    private static auto ref curl() @property { return CurlAPI.instance(); }
+
+    // A handle should not be used by two threads simultaneously
+    private CURL* handle;
+
+    // May also return $(D CURL_READFUNC_ABORT) or $(D CURL_READFUNC_PAUSE)
+    private size_t delegate(OutData) _onSend;
+    private size_t delegate(InData) _onReceive;
+    private void delegate(in char[]) _onReceiveHeader;
+    private CurlSeek delegate(long,CurlSeekPos) _onSeek;
+    private int delegate(curl_socket_t,CurlSockType) _onSocketOption;
+    private int delegate(size_t dltotal, size_t dlnow,
+                         size_t ultotal, size_t ulnow) _onProgress;
+
+    alias requestPause = CurlReadFunc.pause;
+    alias requestAbort = CurlReadFunc.abort;
+
+    /**
+       Initialize the instance by creating a working curl handle.
+    */
+    void initialize()
+    {
+        enforce!CurlException(!handle, "Curl instance already initialized");
+        handle = curl.easy_init();
+        enforce!CurlException(handle, "Curl instance couldn't be initialized");
+        stopped = false;
+        set(CurlOption.nosignal, 1);
+    }
+
+    /**
+       Duplicate this handle.
+
+       The new handle will have all options set as the one it was duplicated
+       from. An exception to this is that all options that cannot be shared
+       across threads are reset thereby making it safe to use the duplicate
+       in a new thread.
+    */
+    Curl dup()
+    {
+        Curl copy;
+        copy.handle = curl.easy_duphandle(handle);
+        copy.stopped = false;
+
+        with (CurlOption) {
+            auto tt = TypeTuple!(file, writefunction, writeheader,
+                headerfunction, infile, readfunction, ioctldata, ioctlfunction,
+                seekdata, seekfunction, sockoptdata, sockoptfunction,
+                opensocketdata, opensocketfunction, progressdata,
+                progressfunction, debugdata, debugfunction, interleavedata,
+                interleavefunction, chunk_data, chunk_bgn_function,
+                chunk_end_function, fnmatch_data, fnmatch_function, cookiejar, postfields);
+
+            foreach(option; tt)
+                copy.clear(option);
+        }
+
+        // The options are only supported by libcurl when it has been built
+        // against certain versions of OpenSSL - if your libcurl uses an old
+        // OpenSSL, or uses an entirely different SSL engine, attempting to
+        // clear these normally will raise an exception
+        copy.clearIfSupported(CurlOption.ssl_ctx_function);
+        copy.clearIfSupported(CurlOption.ssh_keydata);
+
+        // Enable for curl version > 7.21.7
+        static if (LIBCURL_VERSION_MAJOR >= 7 &&
+                   LIBCURL_VERSION_MINOR >= 21 &&
+                   LIBCURL_VERSION_PATCH >= 7)
+        {
+            copy.clear(CurlOption.closesocketdata);
+            copy.clear(CurlOption.closesocketfunction);
+        }
+
+        copy.set(CurlOption.nosignal, 1);
+
+        // copy.clear(CurlOption.ssl_ctx_data); Let ssl function be shared
+        // copy.clear(CurlOption.ssh_keyfunction); Let key function be shared
+
+        /*
+          Allow sharing of conv functions
+          copy.clear(CurlOption.conv_to_network_function);
+          copy.clear(CurlOption.conv_from_network_function);
+          copy.clear(CurlOption.conv_from_utf8_function);
+        */
+
+        return copy;
+    }
+
+    private void _check(CurlCode code)
+    {
+        enforce!CurlTimeoutException(code != CurlError.operation_timedout,
+                                       errorString(code));
+
+        enforce!CurlException(code == CurlError.ok,
+                                errorString(code));
+    }
+
+    private string errorString(CurlCode code)
+    {
+        import core.stdc.string : strlen;
+
+        auto msgZ = curl.easy_strerror(code);
+        // doing the following (instead of just using std.conv.to!string) avoids 1 allocation
+        return format("%s on handle %s", msgZ[0 .. core.stdc.string.strlen(msgZ)], handle);
+    }
+
+    private void throwOnStopped(string message = null)
+    {
+        auto def = "Curl instance called after being cleaned up";
+        enforce!CurlException(!stopped,
+                                message == null ? def : message);
+    }
+
+    /**
+        Stop and invalidate this curl instance.
+        Warning: Do not call this from inside a callback handler e.g. $(D onReceive).
+    */
+    void shutdown()
+    {
+        throwOnStopped();
+        stopped = true;
+        curl.easy_cleanup(this.handle);
+        this.handle = null;
+    }
+
+    /**
+       Pausing and continuing transfers.
+    */
+    void pause(bool sendingPaused, bool receivingPaused)
+    {
+        throwOnStopped();
+        _check(curl.easy_pause(this.handle,
+                               (sendingPaused ? CurlPause.send_cont : CurlPause.send) |
+                               (receivingPaused ? CurlPause.recv_cont : CurlPause.recv)));
+    }
+
+    /**
+       Set a string curl option.
+       Params:
+       option = A $(ECXREF curl, CurlOption) as found in the curl documentation
+       value = The string
+    */
+    void set(CurlOption option, const(char)[] value)
+    {
+        throwOnStopped();
+        _check(curl.easy_setopt(this.handle, option, value.tempCString().buffPtr));
+    }
+
+    /**
+       Set a long curl option.
+       Params:
+       option = A $(ECXREF curl, CurlOption) as found in the curl documentation
+       value = The long
+    */
+    void set(CurlOption option, long value)
+    {
+        throwOnStopped();
+        _check(curl.easy_setopt(this.handle, option, value));
+    }
+
+    /**
+       Set a void* curl option.
+       Params:
+       option = A $(ECXREF curl, CurlOption) as found in the curl documentation
+       value = The pointer
+    */
+    void set(CurlOption option, void* value)
+    {
+        throwOnStopped();
+        _check(curl.easy_setopt(this.handle, option, value));
+    }
+
+    /**
+       Clear a pointer option.
+       Params:
+       option = A $(ECXREF curl, CurlOption) as found in the curl documentation
+    */
+    void clear(CurlOption option)
+    {
+        throwOnStopped();
+        _check(curl.easy_setopt(this.handle, option, null));
+    }
+
+    /**
+       Clear a pointer option. Does not raise an exception if the underlying
+       libcurl does not support the option. Use sparingly.
+       Params:
+       option = A $(ECXREF curl, CurlOption) as found in the curl documentation
+    */
+    void clearIfSupported(CurlOption option)
+    {
+        throwOnStopped();
+        auto rval = curl.easy_setopt(this.handle, option, null);
+        if (rval != CurlError.unknown_option && rval != CurlError.not_built_in)
+            _check(rval);
+    }
+
+    /**
+       perform the curl request by doing the HTTP,FTP etc. as it has
+       been setup beforehand.
+
+       Params:
+       throwOnError = whether to throw an exception or return a CurlCode on error
+    */
+    CurlCode perform(ThrowOnError throwOnError = ThrowOnError.yes)
+    {
+        throwOnStopped();
+        CurlCode code = curl.easy_perform(this.handle);
+        if (throwOnError)
+            _check(code);
+        return code;
+    }
+
+    // Explicitly undocumented. It will be removed in November 2015.
+    deprecated("Pass ThrowOnError.yes or .no instead of a boolean.")
+    CurlCode perform(bool throwOnError)
+    {
+        return perform(cast(ThrowOnError)throwOnError);
+    }
+
+    /**
+      * The event handler that receives incoming data.
+      *
+      * Params:
+      * callback = the callback that receives the $(D ubyte[]) data.
+      * Be sure to copy the incoming data and not store
+      * a slice.
+      *
+      * Returns:
+      * The callback returns the incoming bytes read. If not the entire array is
+      * the request will abort.
+      * The special value HTTP.pauseRequest can be returned in order to pause the
+      * current request.
+      *
+      * Example:
+      * ----
+      * import std.net.curl, std.stdio;
+      * Curl curl;
+      * curl.initialize();
+      * curl.set(CurlOption.url, "http://dlang.org");
+      * curl.onReceive = (ubyte[] data) { writeln("Got data", to!(const(char)[])(data)); return data.length;};
+      * curl.perform();
+      * ----
+      */
+    @property void onReceive(size_t delegate(InData) callback)
+    {
+        _onReceive = (InData id)
+        {
+            throwOnStopped("Receive callback called on cleaned up Curl instance");
+            return callback(id);
+        };
+        set(CurlOption.file, cast(void*) &this);
+        set(CurlOption.writefunction, cast(void*) &Curl._receiveCallback);
+    }
+
+    /**
+      * The event handler that receives incoming headers for protocols
+      * that uses headers.
+      *
+      * Params:
+      * callback = the callback that receives the header string.
+      * Make sure the callback copies the incoming params if
+      * it needs to store it because they are references into
+      * the backend and may very likely change.
+      *
+      * Example:
+      * ----
+      * import std.net.curl, std.stdio;
+      * Curl curl;
+      * curl.initialize();
+      * curl.set(CurlOption.url, "http://dlang.org");
+      * curl.onReceiveHeader = (in char[] header) { writeln(header); };
+      * curl.perform();
+      * ----
+      */
+    @property void onReceiveHeader(void delegate(in char[]) callback)
+    {
+        _onReceiveHeader = (in char[] od)
+        {
+            throwOnStopped("Receive header callback called on "~
+                           "cleaned up Curl instance");
+            callback(od);
+        };
+        set(CurlOption.writeheader, cast(void*) &this);
+        set(CurlOption.headerfunction,
+            cast(void*) &Curl._receiveHeaderCallback);
+    }
+
+    /**
+      * The event handler that gets called when data is needed for sending.
+      *
+      * Params:
+      * callback = the callback that has a $(D void[]) buffer to be filled
+      *
+      * Returns:
+      * The callback returns the number of elements in the buffer that have been
+      * filled and are ready to send.
+      * The special value $(D Curl.abortRequest) can be returned in
+      * order to abort the current request.
+      * The special value $(D Curl.pauseRequest) can be returned in order to
+      * pause the current request.
+      *
+      * Example:
+      * ----
+      * import std.net.curl;
+      * Curl curl;
+      * curl.initialize();
+      * curl.set(CurlOption.url, "http://dlang.org");
+      *
+      * string msg = "Hello world";
+      * curl.onSend = (void[] data)
+      * {
+      *     auto m = cast(void[])msg;
+      *     size_t length = m.length > data.length ? data.length : m.length;
+      *     if (length == 0) return 0;
+      *     data[0..length] = m[0..length];
+      *     msg = msg[length..$];
+      *     return length;
+      * };
+      * curl.perform();
+      * ----
+      */
+    @property void onSend(size_t delegate(OutData) callback)
+    {
+        _onSend = (OutData od)
+        {
+            throwOnStopped("Send callback called on cleaned up Curl instance");
+            return callback(od);
+        };
+        set(CurlOption.infile, cast(void*) &this);
+        set(CurlOption.readfunction, cast(void*) &Curl._sendCallback);
+    }
+
+    /**
+      * The event handler that gets called when the curl backend needs to seek
+      * the data to be sent.
+      *
+      * Params:
+      * callback = the callback that receives a seek offset and a seek position
+      *            $(ECXREF curl, CurlSeekPos)
+      *
+      * Returns:
+      * The callback returns the success state of the seeking
+      * $(ECXREF curl, CurlSeek)
+      *
+      * Example:
+      * ----
+      * import std.net.curl;
+      * Curl curl;
+      * curl.initialize();
+      * curl.set(CurlOption.url, "http://dlang.org");
+      * curl.onSeek = (long p, CurlSeekPos sp)
+      * {
+      *     return CurlSeek.cantseek;
+      * };
+      * curl.perform();
+      * ----
+      */
+    @property void onSeek(CurlSeek delegate(long, CurlSeekPos) callback)
+    {
+        _onSeek = (long ofs, CurlSeekPos sp)
+        {
+            throwOnStopped("Seek callback called on cleaned up Curl instance");
+            return callback(ofs, sp);
+        };
+        set(CurlOption.seekdata, cast(void*) &this);
+        set(CurlOption.seekfunction, cast(void*) &Curl._seekCallback);
+    }
+
+    /**
+      * The event handler that gets called when the net socket has been created
+      * but a $(D connect()) call has not yet been done. This makes it possible to set
+      * misc. socket options.
+      *
+      * Params:
+      * callback = the callback that receives the socket and socket type
+      * $(ECXREF curl, CurlSockType)
+      *
+      * Returns:
+      * Return 0 from the callback to signal success, return 1 to signal error
+      * and make curl close the socket
+      *
+      * Example:
+      * ----
+      * import std.net.curl;
+      * Curl curl;
+      * curl.initialize();
+      * curl.set(CurlOption.url, "http://dlang.org");
+      * curl.onSocketOption = delegate int(curl_socket_t s, CurlSockType t) { /+ do stuff +/ };
+      * curl.perform();
+      * ----
+      */
+    @property void onSocketOption(int delegate(curl_socket_t,
+                                               CurlSockType) callback)
+    {
+        _onSocketOption = (curl_socket_t sock, CurlSockType st)
+        {
+            throwOnStopped("Socket option callback called on "~
+                           "cleaned up Curl instance");
+            return callback(sock, st);
+        };
+        set(CurlOption.sockoptdata, cast(void*) &this);
+        set(CurlOption.sockoptfunction,
+            cast(void*) &Curl._socketOptionCallback);
+    }
+
+    /**
+      * The event handler that gets called to inform of upload/download progress.
+      *
+      * Params:
+      * callback = the callback that receives the (total bytes to download,
+      * currently downloaded bytes, total bytes to upload, currently uploaded
+      * bytes).
+      *
+      * Returns:
+      * Return 0 from the callback to signal success, return non-zero to abort
+      * transfer
+      *
+      * Example:
+      * ----
+      * import std.net.curl;
+      * Curl curl;
+      * curl.initialize();
+      * curl.set(CurlOption.url, "http://dlang.org");
+      * curl.onProgress = delegate int(size_t dltotal, size_t dlnow, size_t ultotal, size_t uln)
+      * {
+      *     writeln("Progress: downloaded bytes ", dlnow, " of ", dltotal);
+      *     writeln("Progress: uploaded bytes ", ulnow, " of ", ultotal);
+      *     curl.perform();
+      * };
+      * ----
+      */
+    @property void onProgress(int delegate(size_t dlTotal,
+                                           size_t dlNow,
+                                           size_t ulTotal,
+                                           size_t ulNow) callback)
+    {
+        _onProgress = (size_t dlt, size_t dln, size_t ult, size_t uln)
+        {
+            throwOnStopped("Progress callback called on cleaned "~
+                           "up Curl instance");
+            return callback(dlt, dln, ult, uln);
+        };
+        set(CurlOption.noprogress, 0);
+        set(CurlOption.progressdata, cast(void*) &this);
+        set(CurlOption.progressfunction, cast(void*) &Curl._progressCallback);
+    }
+
+    // Internal C callbacks to register with libcurl
+    extern (C) private static
+    size_t _receiveCallback(const char* str,
+                            size_t size, size_t nmemb, void* ptr)
+    {
+        auto b = cast(Curl*) ptr;
+        if (b._onReceive != null)
+            return b._onReceive(cast(InData)(str[0..size*nmemb]));
+        return size*nmemb;
+    }
+
+    extern (C) private static
+    size_t _receiveHeaderCallback(const char* str,
+                                  size_t size, size_t nmemb, void* ptr)
+    {
+        auto b = cast(Curl*) ptr;
+        auto s = str[0..size*nmemb].chomp();
+        if (b._onReceiveHeader != null)
+            b._onReceiveHeader(s);
+
+        return size*nmemb;
+    }
+
+    extern (C) private static
+    size_t _sendCallback(char *str, size_t size, size_t nmemb, void *ptr)
+    {
+        Curl* b = cast(Curl*) ptr;
+        auto a = cast(void[]) str[0..size*nmemb];
+        if (b._onSend == null)
+            return 0;
+        return b._onSend(a);
+    }
+
+    extern (C) private static
+    int _seekCallback(void *ptr, curl_off_t offset, int origin)
+    {
+        auto b = cast(Curl*) ptr;
+        if (b._onSeek == null)
+            return CurlSeek.cantseek;
+
+        // origin: CurlSeekPos.set/current/end
+        // return: CurlSeek.ok/fail/cantseek
+        return b._onSeek(cast(long) offset, cast(CurlSeekPos) origin);
+    }
+
+    extern (C) private static
+    int _socketOptionCallback(void *ptr,
+                              curl_socket_t curlfd, curlsocktype purpose)
+    {
+        auto b = cast(Curl*) ptr;
+        if (b._onSocketOption == null)
+            return 0;
+
+        // return: 0 ok, 1 fail
+        return b._onSocketOption(curlfd, cast(CurlSockType) purpose);
+    }
+
+    extern (C) private static
+    int _progressCallback(void *ptr,
+                          double dltotal, double dlnow,
+                          double ultotal, double ulnow)
+    {
+        auto b = cast(Curl*) ptr;
+        if (b._onProgress == null)
+            return 0;
+
+        // return: 0 ok, 1 fail
+        return b._onProgress(cast(size_t)dltotal, cast(size_t)dlnow,
+                             cast(size_t)ultotal, cast(size_t)ulnow);
+    }
+
+}
+
+// Internal messages send between threads.
+// The data is wrapped in this struct in order to ensure that
+// other std.concurrency.receive calls does not pick up our messages
+// by accident.
+private struct CurlMessage(T)
+{
+    public T data;
+}
+
+private static CurlMessage!T curlMessage(T)(T data)
+{
+    return CurlMessage!T(data);
+}
+
+// Pool of to be used for reusing buffers
+private struct Pool(Data)
+{
+    private struct Entry
+    {
+        Data data;
+        Entry* next;
+    }
+    private Entry*  root;
+    private Entry* freeList;
+
+    @safe @property bool empty()
+    {
+        return root == null;
+    }
+
+    @safe nothrow void push(Data d)
+    {
+        if (freeList == null)
+        {
+            // Allocate new Entry since there is no one
+            // available in the freeList
+            freeList = new Entry;
+        }
+        freeList.data = d;
+        Entry* oldroot = root;
+        root = freeList;
+        freeList = freeList.next;
+        root.next = oldroot;
+    }
+
+    @safe Data pop()
+    {
+        enforce!Exception(root != null, "pop() called on empty pool");
+        auto d = root.data;
+        auto n = root.next;
+        root.next = freeList;
+        freeList = root;
+        root = n;
+        return d;
+    }
+}
+
+// Shared function for reading incoming chunks of data and
+// sending the to a parent thread
+private static size_t _receiveAsyncChunks(ubyte[] data, ref ubyte[] outdata,
+                                          Pool!(ubyte[]) freeBuffers,
+                                          ref ubyte[] buffer, Tid fromTid,
+                                          ref bool aborted)
+{
+    immutable datalen = data.length;
+
+    // Copy data to fill active buffer
+    while (!data.empty)
+    {
+
+        // Make sure a buffer is present
+        while ( outdata.empty && freeBuffers.empty)
+        {
+            // Active buffer is invalid and there are no
+            // available buffers in the pool. Wait for buffers
+            // to return from main thread in order to reuse
+            // them.
+            receive((immutable(ubyte)[] buf)
+                    {
+                        buffer = cast(ubyte[])buf;
+                        outdata = buffer[];
+                    },
+                    (bool flag) { aborted = true; }
+                    );
+            if (aborted) return cast(size_t)0;
+        }
+        if (outdata.empty)
+        {
+            buffer = freeBuffers.pop();
+            outdata = buffer[];
+        }
+
+        // Copy data
+        auto copyBytes = outdata.length < data.length ?
+            outdata.length : data.length;
+
+        outdata[0..copyBytes] = data[0..copyBytes];
+        outdata = outdata[copyBytes..$];
+        data = data[copyBytes..$];
+
+        if (outdata.empty)
+            fromTid.send(thisTid, curlMessage(cast(immutable(ubyte)[])buffer));
+    }
+
+    return datalen;
+}
+
+// ditto
+private static void _finalizeAsyncChunks(ubyte[] outdata, ref ubyte[] buffer,
+                                         Tid fromTid)
+{
+    if (!outdata.empty)
+    {
+        // Resize the last buffer
+        buffer.length = buffer.length - outdata.length;
+        fromTid.send(thisTid, curlMessage(cast(immutable(ubyte)[])buffer));
+    }
+}
+
+
+// Shared function for reading incoming lines of data and sending the to a
+// parent thread
+private static size_t _receiveAsyncLines(Terminator, Unit)
+    (const(ubyte)[] data, ref EncodingScheme encodingScheme,
+     bool keepTerminator, Terminator terminator,
+     ref const(ubyte)[] leftOverBytes, ref bool bufferValid,
+     ref Pool!(Unit[]) freeBuffers, ref Unit[] buffer,
+     Tid fromTid, ref bool aborted)
+{
+
+    immutable datalen = data.length;
+
+    // Terminator is specified and buffers should be resized as determined by
+    // the terminator
+
+    // Copy data to active buffer until terminator is found.
+
+    // Decode as many lines as possible
+    while (true)
+    {
+
+        // Make sure a buffer is present
+        while (!bufferValid && freeBuffers.empty)
+        {
+            // Active buffer is invalid and there are no available buffers in
+            // the pool. Wait for buffers to return from main thread in order to
+            // reuse them.
+            receive((immutable(Unit)[] buf)
+                    {
+                        buffer = cast(Unit[])buf;
+                        buffer.length = 0;
+                        buffer.assumeSafeAppend();
+                        bufferValid = true;
+                    },
+                    (bool flag) { aborted = true; }
+                    );
+            if (aborted) return cast(size_t)0;
+        }
+        if (!bufferValid)
+        {
+            buffer = freeBuffers.pop();
+            bufferValid = true;
+        }
+
+        // Try to read a line from left over bytes from last onReceive plus the
+        // newly received bytes.
+        try
+        {
+            if (decodeLineInto(leftOverBytes, data, buffer,
+                               encodingScheme, terminator))
+            {
+                if (keepTerminator)
+                {
+                    fromTid.send(thisTid,
+                                 curlMessage(cast(immutable(Unit)[])buffer));
+                }
+                else
+                {
+                    static if (isArray!Terminator)
+                        fromTid.send(thisTid,
+                                     curlMessage(cast(immutable(Unit)[])
+                                             buffer[0..$-terminator.length]));
+                    else
+                        fromTid.send(thisTid,
+                                     curlMessage(cast(immutable(Unit)[])
+                                             buffer[0..$-1]));
+                }
+                bufferValid = false;
+            }
+            else
+            {
+                // Could not decode an entire line. Save
+                // bytes left in data for next call to
+                // onReceive. Can be up to a max of 4 bytes.
+                enforce!CurlException(data.length <= 4,
+                                        format(
+                                        "Too many bytes left not decoded %s"~
+                                        " > 4. Maybe the charset specified in"~
+                                        " headers does not match "~
+                                        "the actual content downloaded?",
+                                        data.length));
+                leftOverBytes ~= data;
+                break;
+            }
+        }
+        catch (CurlException ex)
+        {
+            prioritySend(fromTid, cast(immutable(CurlException))ex);
+            return cast(size_t)0;
+        }
+    }
+    return datalen;
+}
+
+// ditto
+private static
+void _finalizeAsyncLines(Unit)(bool bufferValid, Unit[] buffer, Tid fromTid)
+{
+    if (bufferValid && buffer.length != 0)
+        fromTid.send(thisTid, curlMessage(cast(immutable(Unit)[])buffer[0..$]));
+}
+
+
+// Spawn a thread for handling the reading of incoming data in the
+// background while the delegate is executing.  This will optimize
+// throughput by allowing simultaneous input (this struct) and
+// output (e.g. AsyncHTTPLineOutputRange).
+private static void _spawnAsync(Conn, Unit, Terminator = void)()
+{
+    Tid fromTid = receiveOnly!Tid();
+
+    // Get buffer to read into
+    Pool!(Unit[]) freeBuffers;  // Free list of buffer objects
+
+    // Number of bytes filled into active buffer
+    Unit[] buffer;
+    bool aborted = false;
+
+    EncodingScheme encodingScheme;
+    static if ( !is(Terminator == void))
+    {
+        // Only lines reading will receive a terminator
+        auto terminator = receiveOnly!Terminator();
+        auto keepTerminator = receiveOnly!bool();
+
+        // max number of bytes to carry over from an onReceive
+        // callback. This is 4 because it is the max code units to
+        // decode a code point in the supported encodings.
+        auto leftOverBytes =  new const(ubyte)[4];
+        leftOverBytes.length = 0;
+        auto bufferValid = false;
+    }
+    else
+    {
+        Unit[] outdata;
+    }
+
+    // no move semantic available in std.concurrency ie. must use casting.
+    auto connDup = cast(CURL*)receiveOnly!ulong();
+    auto client = Conn();
+    client.p.curl.handle = connDup;
+
+    // receive a method for both ftp and http but just use it for http
+    auto method = receiveOnly!(HTTP.Method)();
+
+    client.onReceive = (ubyte[] data)
+    {
+        // If no terminator is specified the chunk size is fixed.
+        static if ( is(Terminator == void) )
+            return _receiveAsyncChunks(data, outdata, freeBuffers, buffer,
+                                       fromTid, aborted);
+        else
+            return _receiveAsyncLines(data, encodingScheme,
+                                      keepTerminator, terminator, leftOverBytes,
+                                      bufferValid, freeBuffers, buffer,
+                                      fromTid, aborted);
+    };
+
+    static if ( is(Conn == HTTP) )
+    {
+        client.method = method;
+        // register dummy header handler
+        client.onReceiveHeader = (in char[] key, in char[] value)
+        {
+            if (key == "content-type")
+                encodingScheme = EncodingScheme.create(client.p.charset);
+        };
+    }
+    else
+    {
+        encodingScheme = EncodingScheme.create(client.encoding);
+    }
+
+    // Start the request
+    CurlCode code;
+    try
+    {
+        code = client.perform(ThrowOnError.no);
+    }
+    catch (Exception ex)
+    {
+        prioritySend(fromTid, cast(immutable(Exception)) ex);
+        fromTid.send(thisTid, curlMessage(true)); // signal done
+        return;
+    }
+
+    if (code != CurlError.ok)
+    {
+        if (aborted && (code == CurlError.aborted_by_callback ||
+                        code == CurlError.write_error))
+        {
+            fromTid.send(thisTid, curlMessage(true)); // signal done
+            return;
+        }
+        prioritySend(fromTid, cast(immutable(CurlException))
+                     new CurlException(client.p.curl.errorString(code)));
+
+        fromTid.send(thisTid, curlMessage(true)); // signal done
+        return;
+    }
+
+    // Send remaining data that is not a full chunk size
+    static if ( is(Terminator == void) )
+        _finalizeAsyncChunks(outdata, buffer, fromTid);
+    else
+        _finalizeAsyncLines(bufferValid, buffer, fromTid);
+
+    fromTid.send(thisTid, curlMessage(true)); // signal done
+}

--- a/patch/std_net_curl.d
+++ b/patch/std_net_curl.d
@@ -1848,7 +1848,7 @@ private mixin template Protocol()
     /**
        The curl handle used by this connection.
     */
-    @property ref Curl handle() return
+    @property ref Curl handle()
     {
         return p.curl;
     }

--- a/src/onedrive.d
+++ b/src/onedrive.d
@@ -18,11 +18,18 @@ class OneDriveException: Exception
 	// HTTP status code
 	int code;
 
+version(GNU) {
+    @safe pure nothrow this(string msg, Throwable next, string file = __FILE__, size_t line = __LINE__)
+    {
+        super(msg, file, line, next);
+    }
+}
+else {
     @nogc @safe pure nothrow this(string msg, Throwable next, string file = __FILE__, size_t line = __LINE__)
     {
         super(msg, file, line, next);
     }
-
+}
 	@safe pure this(int code, string reason, string file = __FILE__, size_t line = __LINE__)
 	{
 		this.code = code;

--- a/src/sync.d
+++ b/src/sync.d
@@ -313,7 +313,7 @@ final class SyncEngine
 	private void deleteItems()
 	{
 		log.vlog("Deleting files ...");
-		int i = pathsToDelete.length - 1; 
+		uint i = cast(uint) pathsToDelete.length - 1; 
 		do {
 			string path = pathsToDelete[i];
 			string id = idsToDelete[i];

--- a/src/sync.d
+++ b/src/sync.d
@@ -33,14 +33,29 @@ private bool testCrc32(string path, const(char)[] crc32)
 
 class SyncException: Exception
 {
-    @nogc @safe pure nothrow this(string msg, string file = __FILE__, size_t line = __LINE__, Throwable next = null)
+    version(GNU)
     {
-        super(msg, file, line, next);
-    }
+        @safe pure nothrow this(string msg, string file = __FILE__, size_t line = __LINE__, Throwable next = null)
+        {
+            super(msg, file, line, next);
+        }
 
-    @nogc @safe pure nothrow this(string msg, Throwable next, string file = __FILE__, size_t line = __LINE__)
+        @safe pure nothrow this(string msg, Throwable next, string file = __FILE__, size_t line = __LINE__)
+        {
+            super(msg, file, line, next);
+        }
+    }
+    else
     {
-        super(msg, file, line, next);
+        @nogc @safe pure nothrow this(string msg, string file = __FILE__, size_t line = __LINE__, Throwable next = null)
+        {
+            super(msg, file, line, next);
+        }
+
+        @nogc @safe pure nothrow this(string msg, Throwable next, string file = __FILE__, size_t line = __LINE__)
+        {
+            super(msg, file, line, next);
+        }
     }
 }
 

--- a/src/util.d
+++ b/src/util.d
@@ -6,6 +6,7 @@ import std.regex;
 import std.socket;
 import std.stdio;
 import std.string;
+import std.net.curl;
 
 private string deviceName;
 
@@ -82,9 +83,12 @@ Regex!char wild2regex(const(char)[] pattern)
 bool testNetwork()
 {
 	try {
-		auto addr = new InternetAddress("login.live.com", 443);
-		auto socket = new TcpSocket(addr);
-		return socket.isAlive();
+	        HTTP http = HTTP();
+		http.onReceive = (ubyte[] data) { return data.length; };
+	        http.method = HTTP.Method.get;
+	        http.url = "https://login.live.com";
+		http.perform();
+		return true;
 	} catch (SocketException) {
 		return false;
 	}


### PR DESCRIPTION
Here are my fixes for:
1. When a non-empty directory is reported has been deleted remotely, the local client does not delete the tree properly causing itself to re-upload the whole tree.
2. Working with a connection through proxy (as the libcurl should do). 

Cheers.