### PR TITLE
Allow for graceful continuing on upload errors

### DIFF
--- a/src/config.d
+++ b/src/config.d
@@ -7,17 +7,19 @@ final class Config
 	public string statusTokenFilePath;
 	public string databaseFilePath;
 	public string uploadStateFilePath;
+	public bool ignoreUploadErrors;
 
 	private string userConfigFilePath;
 	// hashmap for the values found in the user config file
 	private string[string] values;
 
-	this(string configDirName)
+	this(string configDirName, bool ignoreErrors)
 	{
 		refreshTokenFilePath = configDirName ~ "/refresh_token";
 		statusTokenFilePath = configDirName ~ "/status_token";
 		databaseFilePath = configDirName ~ "/items.sqlite3";
 		uploadStateFilePath = configDirName ~ "/resume_upload";
+		ignoreUploadErrors = ignoreErrors;
 		userConfigFilePath = configDirName ~ "/config";
 	}
 
@@ -72,7 +74,7 @@ final class Config
 
 unittest
 {
-	auto cfg = new Config("");
+	auto cfg = new Config("", false);
 	cfg.load("onedrive.conf");
 	assert(cfg.getValue("sync_dir") == "~/OneDrive");
 	assert(cfg.getValue("empty", "default") == "default");

--- a/src/main.d
+++ b/src/main.d
@@ -16,6 +16,8 @@ int main(string[] args)
 	bool logout;
 	// enable verbose logging
 	bool verbose;
+	// ignore upload errors
+	bool ignoreErrors;
 
 	try {
 		auto opt = getopt(
@@ -25,6 +27,7 @@ int main(string[] args)
 			"resync", "Forget the last saved state, perform a full sync.", &resync,
 			"logout", "Logout the current user.", &logout,
 			"confdir", "Set the directory to use to store the configuration files.", &configDirName,
+			"ignore-errors|i", "Ignore upload errors", &ignoreErrors,
 			"verbose|v", "Print more details, useful for debugging.", &log.verbose
 		);
 		if (opt.helpWanted) {
@@ -44,7 +47,7 @@ int main(string[] args)
 	log.vlog("Loading config ...");
 	configDirName = expandTilde(configDirName);
 	if (!exists(configDirName)) mkdir(configDirName);
-	auto cfg = new config.Config(configDirName);
+	auto cfg = new config.Config(configDirName, ignoreErrors);
 	cfg.init();
 
 	// upgrades

--- a/src/onedrive.d
+++ b/src/onedrive.d
@@ -79,7 +79,7 @@ final class OneDriveApi
 	{
 		import std.stdio, std.regex;
 		char[] response;
-		string url = authUrl ~ "?client_id=" ~ clientId ~ "&scope=files.readwrite.all%20offline_access&response_type=code&redirect_uri=" ~ redirectUrl;
+		string url = authUrl ~ "?client_id=" ~ clientId ~ "&scope=files.readwrite%20files.readwrite.all%20offline_access&response_type=code&redirect_uri=" ~ redirectUrl;
 		log.log("Authorize this app visiting:\n");
 		write(url, "\n\n", "Enter the response uri: ");
 		readln(response);

--- a/src/sync.d
+++ b/src/sync.d
@@ -485,10 +485,16 @@ final class SyncEngine
 	{
 		log.log("Uploading: ", path);
 		JSONValue response;
-		if (getSize(path) <= thresholdFileSize) {
-			response = onedrive.simpleUpload(path, path);
-		} else {
-			response = session.upload(path, path);
+		try {
+			if (getSize(path) <= thresholdFileSize) {
+				response = onedrive.simpleUpload(path, path);
+			} else {
+				response = session.upload(path, path);
+			}
+		} catch (OneDriveException e) {
+			if (!cfg.ignoreUploadErrors) throw e;
+			else log.log("Error on upload: ", e.error["error"]["message"]);
+			return;
 		}
 		string id = response["id"].str;
 		string cTag = response["cTag"].str;


### PR DESCRIPTION
In syncing my drive, it kept failing due to upload errors, usually due to filenames that are allowed in Linux but apparently not in OneDrive.  I would have preferred to let it chug along without exiting on those errors, and I could go in after and clean them up and try again.  To this effect, I created a new option to allow the user to ignore upload errors and continue (with a message stating what the error was).