### PR TITLE
Change regex for authorization code

### DIFF
--- a/src/onedrive.d
+++ b/src/onedrive.d
@@ -84,7 +84,7 @@ final class OneDriveApi
 		write(url, "\n\n", "Enter the response uri: ");
 		readln(response);
 		// match the authorization code
-		auto c = matchFirst(response, r"(?:code=)(([\w\d]+-){4}[\w\d]+)");
+		auto c = matchFirst(response, r"(?:code=)([^&]+)");
 		if (c.empty) {
 			log.log("Invalid uri");
 			return false;


### PR DESCRIPTION
Change regex to extract authorization code to work with OneDrive for Business. #143 