### PR TITLE
fix #171: unnecessary moving in the root directory

### DIFF
--- a/src/sync.d
+++ b/src/sync.d
@@ -275,7 +275,7 @@ final class SyncEngine
 		assert(oldItem.type == newItem.type);
 
 		if (oldItem.eTag != newItem.eTag) {
-			string oldPath = itemdb.computePath(oldItem.id);
+			string oldPath = itemdb.computePath(oldItem.parentId) ~ '/' ~ oldItem.name;
 			if (oldPath != newPath) {
 				log.log("Moving: ", oldPath, " -> ", newPath);
 				if (exists(newPath)) {


### PR DESCRIPTION
fixing #171 

In `applyChangedItem`(`sync.d`) function, the variable `newpath` was `./<filename>` but `oldpath` was `<filename>` if the file is in the root directory. Therefore, it calls the unnecessary `safeRename` function and many copies of the file are created.