### PR TITLE
Add service filename to Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,7 @@ clean:
 
 install: all
 	install -D onedrive $(DESTDIR)$(PREFIX)/bin/onedrive
-	install -D -m 644 onedrive.service $(DESTDIR)/usr/lib/systemd/user
+	install -D -m 644 onedrive.service $(DESTDIR)/usr/lib/systemd/user/onedrive.service
 
 uninstall:
 	rm -f $(DESTDIR)$(PREFIX)/bin/onedrive


### PR DESCRIPTION
When the dir the file is being installed to doesn't exist (like when setting DESTDIR), "install" will take the last part as the filename. A file called "/usr/lib/systemd/user" doesn't work correctly.