### PR TITLE
Fixed bugs that cannot create nested directories.

### DIFF
--- a/src/onedrive.d
+++ b/src/onedrive.d
@@ -100,9 +100,13 @@ final class OneDriveApi
 	void downloadById(const(char)[] id, string saveToPath)
 	{
 		checkAccessTokenExpired();
+		import std.file;
 		scope(failure) {
-			import std.file;
 			if (exists(saveToPath)) remove(saveToPath);
+		}
+		// mkdir if need, or File(saveToPath, "wb") may fail
+		if ( !exists(dirName(saveToPath)) ) {
+		   mkdirRecurse(dirName(saveToPath));
 		}
 		const(char)[] url = itemByIdUrl ~ id ~ "/content?AVOverride=1";
 		download(url, saveToPath);

--- a/src/sync.d
+++ b/src/sync.d
@@ -243,7 +243,8 @@ final class SyncEngine
 			break;
 		case ItemType.dir:
 			log.log("Creating directory: ", path);
-			mkdir(path);
+			//Use mkdirRecuse to deal nested dir
+			mkdirRecurse(path);
 			break;
 		}
 		setTimes(path, item.mtime, item.mtime);


### PR DESCRIPTION
1. Replaced mkdir by mkdirRecurse in applyNewItem() to deal with nested directories.

2. In downloadById(), before download an item, check if its dirName exists, if not, use mkdirRecurse to build it.