### PR TITLE
Update onedrive.service.in to Restart=always

### DIFF
--- a/onedrive.service.in
+++ b/onedrive.service.in
@@ -4,7 +4,7 @@ Documentation=https://github.com/skilion/onedrive
 
 [Service]
 ExecStart=@PREFIX@/bin/onedrive -m
-Restart=no
+Restart=always
 
 [Install]
 WantedBy=default.target


### PR DESCRIPTION
Restart service on crash until recoverable errors are handled more gracefully. "Restart=no" leads to users not realizing that the daemon has crashed and their local file versions are out of sync.