### PR TITLE
Explain purpose of DESTDIR and PREFIX

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,6 @@
 DFLAGS = -ofonedrive -L-lcurl -L-lsqlite3 -L-ldl -J.
 PREFIX = /usr/local
+DESTDIR = /
 
 SOURCES = \
 	src/config.d \
@@ -24,21 +25,21 @@ debug: version $(SOURCES)
 	dmd -debug -g -gs $(DFLAGS) $(SOURCES)
 
 install: all
-	install -D onedrive $(DESTDIR)$(PREFIX)/bin/onedrive
-	install -D -m 644 onedrive.service $(DESTDIR)/usr/lib/systemd/user/onedrive.service
+	install -D onedrive $(DESTDIR)/$(PREFIX)/bin/onedrive
+	install -D -m 644 onedrive.service $(DESTDIR)/$(PREFIX)/share/systemd/user/onedrive.service
 
 onedrive: version $(SOURCES)
 	dmd -g -inline -O -release $(DFLAGS) $(SOURCES)
 
-onedrive.service:
-	sed "s|@PREFIX@|$(PREFIX)|g" onedrive.service.in > onedrive.service
+onedrive.service: onedrive.service.in
+	sed "s|@DESTDIR@/@PREFIX@|$(DESTDIR)/$(PREFIX)|g" onedrive.service.in > onedrive.service
 
 unittest: $(SOURCES)
 	dmd -debug -g -gs -unittest $(DFLAGS) $(SOURCES)
 
 uninstall:
-	rm -f $(DESTDIR)$(PREFIX)/bin/onedrive
-	rm -f $(DESTDIR)/usr/lib/systemd/user/onedrive.service
+	rm -f $(DESTDIR)/$(PREFIX)/bin/onedrive
+	rm -f $(DESTDIR)/$(PREFIX)/share/systemd/user/onedrive.service
 
 version: .git/HEAD .git/index
 	echo $(shell git describe --tags 2>/dev/null) >version

--- a/onedrive.service.in
+++ b/onedrive.service.in
@@ -3,7 +3,7 @@ Description=OneDrive Free Client
 Documentation=https://github.com/skilion/onedrive
 
 [Service]
-ExecStart=@PREFIX@/bin/onedrive -m
+ExecStart=@DESTDIR@/@PREFIX@/bin/onedrive -m -v
 Restart=no
 
 [Install]


### PR DESCRIPTION
I've been able to build and use this client for a couple days now from the build directory, but i'm unsure of how to install it properly. I would like to avoid using `sudo` and installing it into my `/usr/local` directory.

I tried installing it in a directory next to the source, but it resulted in a pretty unusual directory structure:

```bash
$ tree . -d
.
├── install
│   └── usr
│       ├── lib
│       │   └── systemd
│       │       └── user
│       └── local
│           └── bin
└── onedrive-src
    └── src
```

Could someone explain to me if it's possible to install the service somewhere else? Does using `onedrive` as a service require it to be in `/usr/local`?

I'd be happy to put this information onto the wiki if I can understand it