### PR TITLE
invalid_grant, error 70000

### DIFF
--- a/src/onedrive.d
+++ b/src/onedrive.d
@@ -75,7 +75,7 @@ final class OneDriveApi
 		write(url, "\n\n", "Enter the response uri: ");
 		readln(response);
 		// match the authorization code
-		auto c = matchFirst(response, r"(?:(\?|&)code=)([\w\d-]+)");
+		auto c = matchFirst(response, r"(?:[\?|&]code=)([\w\d-]+)");
 		if (c.empty) {
 			log.log("Invalid uri");
 			return false;


### PR DESCRIPTION
when trying to redeem an code, this error always occured, no matter
which parts of the response uri/url that was used.

the old regexp for parsing the code contained 3 groups, where as the
actual code always was the last group, and the second group was either ?
or &, and the first group would've been everything up until "code=".

changed from a matching group to character class so there would only be
two matching groups, so calling popFront() would actually leave the
authorization code in the front.