### PR TITLE
Ubuntu dmd dependency installation was failing

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,9 +23,7 @@
 ```sh
 sudo apt install libcurl4-openssl-dev
 sudo apt install libsqlite3-dev
-sudo wget http://master.dl.sourceforge.net/project/d-apt/files/d-apt.list -O /etc/apt/sources.list.d/d-apt.list
-sudo apt-get update && sudo apt-get -y --allow-unauthenticated install --reinstall d-apt-keyring
-sudo apt-get update && sudo apt-get install dmd-compiler dub
+curl -fsS https://dlang.org/install.sh | bash -s dmd
 ```
 
 ### Dependencies: Fedora/CentOS


### PR DESCRIPTION
The apt-get method doesn't work out of the box on newer ubuntu systems due to security concerns. I recommend changing the download of dmd to the recommended method by the d-lang team.