### PR TITLE
Add ability to exclude paths explicitly from syncing

### DIFF
--- a/src/selective.d
+++ b/src/selective.d
@@ -38,27 +38,51 @@ final class SelectiveSync
 	}
 }
 
-// test if the given path is not included in the allowed paths
-// if there are no allowed paths always return false
-private bool isPathExcluded(string path, string[] allowedPaths)
+// Test if the given path is included or excluded from syncronization.
+//
+// Iterate through the list of inclusion/exclusion paths in
+// pathList. If the test path is a prefix of or equal to the given
+// path, apply the respective action:
+//
+// A test path starting with '-' means exclude
+// A path starting with '+' means include
+// A path starting with any other character means include.
+//
+// A '+' or '-' as the first character is stripped of before
+// comparision.
+//
+private bool isPathExcluded(string path, string[] pathList)
 {
-	// always allow the root
+	// always include the root
 	if (path == ".") return false;
-	// if there are no allowed paths always return false
-	if (allowedPaths.empty) return false;
+	// if there are no paths to check always include
+	if (pathList.empty) return false;
 
 	path = buildNormalizedPath(path);
-	foreach (allowed; allowedPaths) {
-		auto comm = commonPrefix(path, allowed);
-		if (comm.length == path.length) {
-			// the given path is contained in an allowed path
-			return false;
+	bool exclude;
+	int offset;
+	foreach (testPath; pathList) {
+		switch (testPath[0]) {
+		case '-':
+			exclude = true;
+			offset = 1;
+			break;
+		case '+':
+			offset = 1;
+			exclude = false;
+			break;
+		default:
+			offset = 0;
+			exclude = false;
 		}
-		if (comm.length == allowed.length && path[comm.length] == '/') {
-			// the given path is a subitem of an allowed path
-			return false;
+		auto comm = commonPrefix(path, testPath[offset..$]);
+		if (comm.length == testPath[offset..$].length) {
+			// path is contained in testPath:
+			// in/exclude according to type of testPath
+			return exclude;
 		}
 	}
+	// exclude any unmatched path
 	return true;
 }
 
@@ -69,4 +93,8 @@ unittest
 	assert(!isPathExcluded("Documents/a.txt", ["Documents"]));
 	assert(isPathExcluded("Hello/World", ["Hello/John"]));
 	assert(!isPathExcluded(".", ["Documents"]));
+	assert(!isPathExcluded("any",["+."]));
+	assert(isPathExcluded("nothing",["-."]));
+	assert(!isPathExcluded("some/path", ["+some/path", "-."]));
+	assert(!isPathExcluded("some/path/below", ["some", "-some/path"]));
 }


### PR DESCRIPTION
This patch expands the syntax of the 'sync_list' file. If a line is
prefixed with '-' the rest of the line is a path to be excluded from
syncing. If it is prefixed with '+' the rest of the line is a path to be
synced.

This allows to sync a directory, but to exclude a sub directory of it,