### PR TITLE
Service templates for multiple accounts

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,24 +16,27 @@ SOURCES = \
 	src/upload.d \
 	src/util.d
 
-all: onedrive onedrive.service
+all: onedrive onedrive.service onedrive@.service
 
 clean:
-	rm -f onedrive onedrive.o onedrive.service
+	rm -f onedrive onedrive.o onedrive.service onedrive@.service
 
 install: all
 	install -D onedrive $(DESTDIR)$(PREFIX)/bin/onedrive
 	install -D -m 644 onedrive.service $(DESTDIR)/usr/lib/systemd/user/onedrive.service
+	install -D -m 644 onedrive@.service $(DESTDIR)/usr/lib/systemd/user/onedrive@.service
 
 onedrive: version $(SOURCES)
 	$(DC) $(DFLAGS) $(SOURCES)
 
 onedrive.service:
 	sed "s|@PREFIX@|$(PREFIX)|g" onedrive.service.in > onedrive.service
+	sed "s|@PREFIX@|$(PREFIX)|g" onedrive@.service.in > onedrive@.service
 
 uninstall:
 	rm -f $(DESTDIR)$(PREFIX)/bin/onedrive
 	rm -f $(DESTDIR)/usr/lib/systemd/user/onedrive.service
+	rm -f $(DESTDIR)/usr/lib/systemd/user/onedrive@.service
 
 version: .git/HEAD .git/index
 	echo $(shell git describe --tags) >version

--- a/README.md
+++ b/README.md
@@ -110,6 +110,11 @@ To see the logs run:
 journalctl --user-unit onedrive -f
 ```
 
+If you want to allow your files to sync even when you're not logged in, you need to enable systemd's user linger function:
+```sh
+loginctl enable-linger USERNAME
+```
+
 Note: systemd is supported on Ubuntu only starting from version 15.04
 
 ### Using multiple accounts
@@ -124,6 +129,26 @@ onedrive --monitor --confdir="~/.config/onedriveWork" &
 `--monitor` keeps the application running and monitoring for changes
 
 `&` puts the application in background and leaves the terminal interactive
+
+If you want to do automatic file sync with multiple accounts:
+```sh
+cp -fv /usr/lib/systemd/user/onedrive@.service ~/.config/systemd/user/onedrive@CONFIGDIR
+```
+CONFIGDIR should be replaced with the directory name inside ~/.config where your config is stored
+
+Example:
+```sh
+cp -fv /usr/lib/systemd/user/onedrive@.service ~/.config/systemd/user/onedrive@onedrivePersonal
+cp -fv /usr/lib/systemd/user/onedrive@.service ~/.config/systemd/user/onedrive@onedriveWork
+```
+
+Then, just enable and start the services:
+```sh
+systemctl --user enable onedrive@onedrivePersonal
+systemctl --user enable onedrive@onedriveWork
+systemctl --user start onedrive@onedrivePersonal
+systemctl --user start onedrive@onedriveWork
+```
 
 ## Extra
 

--- a/onedrive.service.in
+++ b/onedrive.service.in
@@ -1,6 +1,7 @@
 [Unit]
 Description=OneDrive Free Client
 Documentation=https://github.com/skilion/onedrive
+After=network.target
 
 [Service]
 ExecStart=@PREFIX@/bin/onedrive -m

--- a/onedrive@.service.in
+++ b/onedrive@.service.in
@@ -1,0 +1,11 @@
+[Unit]
+Description=OneDrive Free Client
+Documentation=https://github.com/skilion/onedrive
+After=network.target
+
+[Service]
+ExecStart=@PREFIX@/bin/onedrive -m --confdir="~/.config/%i"
+Restart=no
+
+[Install]
+WantedBy=default.target

--- a/src/sync.d
+++ b/src/sync.d
@@ -44,7 +44,7 @@ private Item makeItem(const ref JSONValue driveItem)
 		name: "name" in driveItem ? driveItem["name"].str : null, // name may be missing for deleted files in OneDrive Biz
 		eTag: "eTag" in driveItem ? driveItem["eTag"].str : null, // eTag is not returned for the root in OneDrive Biz
 		cTag: "cTag" in driveItem ? driveItem["cTag"].str : null, // cTag is missing in old files (and all folders in OneDrive Biz)
-		mtime: "fileSystemInfo" in driveItem ? SysTime.fromISOExtString(driveItem["fileSystemInfo"]["lastModifiedDateTime"].str) : SysTime(0),
+		mtime: ("fileSystemInfo" in driveItem && "lastModifiedDateTime" in driveItem["fileSystemInfo"])? SysTime.fromISOExtString(driveItem["fileSystemInfo"]["lastModifiedDateTime"].str) : SysTime(0),
 	};
 
 	if (isItemFile(driveItem)) {


### PR DESCRIPTION
Added a dependency for the network to the systemd service files (for cases where lingering has been enabled for a user).

Added a service template to make accommodating multiple accounts easier in systemd.