### PR TITLE
refactoring callback stdlib atoi

### DIFF
--- a/src/sqlite.d
+++ b/src/sqlite.d
@@ -68,7 +68,7 @@ struct Database
 	{
 		int userVersion;
 		extern (C) int callback(void* user_version, int count, char** column_text, char** column_name) {
-			import std.c.stdlib: atoi;
+			import core.stdc.stdlib: atoi;
 			*(cast(int*) user_version) = atoi(*column_text);
 			return 0;
 		}


### PR DESCRIPTION
I have some problem when I was make in folder

src/sqlite.d(71): Error: module `stdlib` is in file 'std/c/stdlib.d' which cannot be read

So, I look for in https://dlang.org/library/core/stdc/stdlib/atoi.html and change the import.

Thanks
Marcos