### PR TITLE
Change stdlib path to the most recent update

### DIFF
--- a/src/sqlite.d
+++ b/src/sqlite.d
@@ -68,7 +68,7 @@ struct Database
 	{
 		int userVersion;
 		extern (C) int callback(void* user_version, int count, char** column_text, char** column_name) {
-			import std.c.stdlib: atoi;
+			import core.stdc.stdlib: atoi;
 			*(cast(int*) user_version) = atoi(*column_text);
 			return 0;
 		}


### PR DESCRIPTION
"std.c.stdlib" is deprecated, so we can use core.stdc.stdlib which provides "atoi".