### PR TITLE
Provide command for first start

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,9 @@ make DC=ldmd2
 
 ### First run :zap:
 After installing the application you must run it at least once from the terminal to authorize it.
+```sh
+./onedrive
+```
 
 You will be asked to open a specific link using your web browser where you will have to login into your Microsoft Account and give the application the permission to access your files. After giving the permission, you will be redirected to a blank page. Copy the URI of the blank page into the application.
 


### PR DESCRIPTION
The readme currently only states **what** users have to do during first launch, it does not state **the command to launch the application** manually however.