### PR TITLE
Fixing onedrive.service.in to restart the service on failure

### DIFF
--- a/onedrive.service.in
+++ b/onedrive.service.in
@@ -4,7 +4,7 @@ Documentation=https://github.com/skilion/onedrive
 
 [Service]
 ExecStart=@PREFIX@/bin/onedrive -m
-Restart=no
+Restart=on-failure
 
 [Install]
 WantedBy=default.target


### PR DESCRIPTION
The systemd service is failing even for temporary issue like,  network connection disabled for a while. The service is not restarted and the synch process is stopped until next restart. Adding Restart=on-failure to service file will restart the service for such failures. 